### PR TITLE
CLAUDE.md: Read 도구 기본 limit을 4000으로 지정하는 규칙 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,7 @@
 # GEO Agent System — 작업 기록 및 지침
 
+> **Claude Code 도구 규칙**: Read 도구 사용 시 limit을 명시하지 않을 경우 항상 `limit: 4000`을 지정하라.
+
 ## 프로젝트 개요
 
 **GEO (Generative Engine Optimization)** Agent System: LLM 서비스(ChatGPT, Claude, Gemini, Perplexity 등)가 Target Web Page의 데이터를 우선적으로, 정확하게 참조하도록 콘텐츠를 최적화하는 에이전트 시스템.


### PR DESCRIPTION
ARCHITECTURE.md(3325줄) 등 대형 파일의 후반부 누락 방지를 위해
Read 도구 호출 시 limit: 4000을 항상 명시하도록 지시 추가.