### PR TITLE
feat: Dashboard 우상단에 빌드 시점 commit SHA + 날짜/시간 표시

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -12,7 +12,7 @@
 		}
 	},
 	"scripts": {
-		"build": "tsc -b && node -e \"const fs=require('fs'),p=require('path');const s=p.join('src','ui');const d=p.join('dist','ui');fs.mkdirSync(d,{recursive:true});fs.readdirSync(s).filter(f=>f.endsWith('.html')).forEach(f=>fs.copyFileSync(p.join(s,f),p.join(d,f)));\"",
+		"build": "tsc -b && node -e \"const fs=require('fs'),p=require('path');const s=p.join('src','ui');const d=p.join('dist','ui');fs.mkdirSync(d,{recursive:true});fs.readdirSync(s).filter(f=>f.endsWith('.html')).forEach(f=>fs.copyFileSync(p.join(s,f),p.join(d,f)));\" && node -e \"const{execSync:e}=require('child_process'),fs=require('fs'),p=require('path');try{const sha=e('git rev-parse HEAD',{encoding:'utf-8'}).trim();const date=e('git log -1 --format=%ci',{encoding:'utf-8'}).trim();fs.writeFileSync(p.join('dist','build-info.json'),JSON.stringify({sha,date,short:sha.slice(0,7),buildTime:new Date().toISOString()}));}catch{fs.writeFileSync(p.join('dist','build-info.json'),JSON.stringify({sha:'unknown',date:'unknown',short:'unknown',buildTime:new Date().toISOString()}));}\"",
 		"dev": "node --import tsx src/server.ts",
 		"test": "vitest run",
 		"clean": "rimraf dist .tsbuildinfo"

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -138,14 +138,24 @@ app.get("/dashboard", (c) => {
 });
 
 // Root — API info + dashboard link
-// ── Git version info (cached at startup) ─────────────────────
+// ── Build-time version info ──────────────────────────────────
 let gitInfo = { sha: "unknown", date: "unknown", short: "unknown" };
 try {
-	const sha = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
-	const date = execSync("git log -1 --format=%ci", { encoding: "utf-8" }).trim();
-	gitInfo = { sha, date, short: sha.slice(0, 7) };
+	const buildInfoPath = join(__dirname, "build-info.json");
+	const raw = readFileSync(buildInfoPath, "utf-8");
+	const info = JSON.parse(raw);
+	gitInfo = { sha: info.sha, date: info.date, short: info.short };
 } catch {
-	// Not a git repo or git not available
+	// build-info.json not found (dev mode) — fall back to live git
+	try {
+		const sha = execSync("git rev-parse HEAD", { encoding: "utf-8" }).trim();
+		const date = execSync("git log -1 --format=%ci", {
+			encoding: "utf-8",
+		}).trim();
+		gitInfo = { sha, date, short: sha.slice(0, 7) };
+	} catch {
+		// Not a git repo or git not available
+	}
 }
 
 app.get("/api/version", (c) => c.json(gitInfo));

--- a/packages/dashboard/src/ui/dashboard.html
+++ b/packages/dashboard/src/ui/dashboard.html
@@ -1945,10 +1945,14 @@ function esc(s) { const d = document.createElement('div'); d.textContent = s || 
 // ── Init ─────────────────────────────────────────────
 checkHealth();
 
-// Load version info
+// Load version info (build-time commit SHA + date/time)
 api('/api/version').then(function(v) {
-	document.getElementById('versionInfo').textContent = v.short + ' · ' + v.date.split(' ')[0];
-	document.getElementById('versionInfo').title = 'Commit: ' + v.sha + '\nDate: ' + v.date;
+	var parts = v.date.split(' ');
+	var dateStr = parts[0] || '';
+	var timeStr = (parts[1] || '').replace(/:\d{2}$/, ''); // HH:MM (drop seconds)
+	var display = v.short + ' · ' + dateStr + ' ' + timeStr;
+	document.getElementById('versionInfo').textContent = display.trim();
+	document.getElementById('versionInfo').title = 'Build Commit: ' + v.sha + '\nDate: ' + v.date;
 }).catch(function() { /* ignore */ });
 
 // Restore active tab from URL hash, default to 'targets'


### PR DESCRIPTION
빌드 스크립트에서 git commit 정보를 build-info.json으로 임베딩하고,
서버가 이를 읽어 /api/version으로 제공. dev 모드에서는 런타임 git fallback. UI 표시 형식: `277873c · 2026-03-21 23:40`