### PR TITLE
Fix: ReportBuilder generated_at 타이밍 버그 (CI Node 20 Ubuntu)

### DIFF
--- a/packages/core/src/report/report-generator.ts
+++ b/packages/core/src/report/report-generator.ts
@@ -62,7 +62,6 @@ export class ReportBuilder {
 			report_id: reportId,
 			target_id: targetId,
 			target_url: targetUrl,
-			generated_at: new Date().toISOString(),
 		};
 	}
 
@@ -120,6 +119,7 @@ export class ReportBuilder {
 	build(): OptimizationReport {
 		return OptimizationReportSchema.parse({
 			...this.report,
+			generated_at: new Date().toISOString(),
 			changes: this._changes,
 			score_comparisons: this._scoreComparisons,
 			key_improvements: this._keyImprovements,


### PR DESCRIPTION
## Summary
- `ReportBuilder.generated_at`을 constructor → `build()` 시점으로 이동
- `beforeEach`에서 builder 생성 후 테스트 본문에서 시각 비교 시, constructor 시점이 더 이전이라 `>=` 비교 실패하는 문제 해결
- Node 20 + Ubuntu에서만 재현되던 CI 타이밍 버그 (PR #21 CI 실패 원인)

## Test plan
- [x] `report-generator.test.ts` 38 tests 전부 통과 확인
- [ ] CI 전 matrix (ubuntu/windows × node 20/22) 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)