### PR TITLE
Feat: Agent Prompt의 Customization 제공 및 workspace 경로 추가

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,8 @@ program
 		initWorkspace(settings);
 
 		console.log("🚀 Starting GEO Agent System...");
+		console.log(`💾 Workspace: ${settings.workspace_dir}`);
+		console.log("   (Agent Prompts는 이 경로에 저장됩니다. GEO_WORKSPACE 환경변수로 변경 가능)");
 		await startServer(port, hostname);
 		console.log(`📊 Dashboard: http://${hostname}:${port}/dashboard`);
 	});

--- a/packages/core/src/prompts/prompt-loader.ts
+++ b/packages/core/src/prompts/prompt-loader.ts
@@ -35,10 +35,15 @@ export function loadPrompt(workspaceDir: string, agentId: AgentId): AgentPromptC
  */
 export function savePrompt(workspaceDir: string, config: AgentPromptConfig): void {
 	const promptDir = path.join(workspaceDir, "prompts");
-	fs.mkdirSync(promptDir, { recursive: true });
-
 	const filePath = path.join(promptDir, `${config.agent_id}.json`);
-	fs.writeFileSync(filePath, JSON.stringify(config, null, 2));
+	try {
+		fs.mkdirSync(promptDir, { recursive: true });
+		fs.writeFileSync(filePath, JSON.stringify(config, null, 2));
+	} catch (err) {
+		throw new Error(
+			`Failed to save prompt '${config.agent_id}' to ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
 }
 
 /**

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -56,7 +56,14 @@ settingsRouter.put("/agents/prompts/:agent_id", async (c) => {
 		last_modified: new Date().toISOString(),
 	};
 
-	savePrompt(getWorkspaceDir(), config);
+	try {
+		savePrompt(getWorkspaceDir(), config);
+	} catch (err) {
+		return c.json(
+			{ error: "Failed to save prompt", message: err instanceof Error ? err.message : String(err) },
+			500,
+		);
+	}
 	return c.json(config);
 });
 

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -1,5 +1,5 @@
 import { execSync } from "node:child_process";
-import { readFileSync } from "node:fs";
+import { readFileSync, readdirSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -202,6 +202,20 @@ export async function startServer(
 ): Promise<{ settings: AppSettings; server: ServerType }> {
 	const settings = loadSettings();
 	initWorkspace(settings);
+
+	// 워크스페이스 경로 및 커스텀 프롬프트 로딩 상태 출력
+	const promptsDir = join(settings.workspace_dir, "prompts");
+	let customPromptInfo = "커스텀 없음 (기본값 사용 중)";
+	try {
+		const files = readdirSync(promptsDir).filter((f) => f.endsWith(".json"));
+		if (files.length > 0) {
+			customPromptInfo = `커스텀 ${files.length}개 로드됨 (${files.join(", ")})`;
+		}
+	} catch {
+		// prompts 디렉토리가 아직 없는 경우 — initWorkspace가 생성함
+	}
+	console.log(`💾 Workspace: ${settings.workspace_dir}`);
+	console.log(`   Prompts: ${customPromptInfo}`);
 
 	// Initialize database and inject into routers
 	const db = createDatabase(settings);


### PR DESCRIPTION
- Agent Prompts에 대한  Customization의 save & load 기능 제공
- cli/index.ts start 커맨드: workspace 경로 및 GEO_WORKSPACE 안내 메시지 출력
- savePrompt(): 파일 쓰기 실패 시 경로 포함 명확한 에러 메시지 throw
- settings.ts PUT 핸들러: savePrompt 실패 시 500 에러를 클라이언트에 전달 (기존: 에러 숨김)

https://claude.ai/code/session_018Nmou8o7TamfXsKZ7iUiZU

## Preview
<img width="350" alt="image" src="https://github.com/user-attachments/assets/ee0b1b14-f4df-481e-84f9-957bf50cf9a0" />
