### PR TITLE
Feat: 대시보드 헤더에 Redeploy 버튼 추가 — 원클릭 서버 업데이트/재시작

### DIFF
--- a/packages/core/src/llm/geo-llm-client.integration.test.ts
+++ b/packages/core/src/llm/geo-llm-client.integration.test.ts
@@ -94,7 +94,7 @@ describe("GeoLLMClient — real API integration", () => {
 
 			const response = await client.chat({
 				prompt: "Say hello in one word.",
-				max_tokens: 10,
+				max_tokens: 16,
 				temperature: 0,
 				json_mode: false,
 			});

--- a/packages/dashboard/src/server.ts
+++ b/packages/dashboard/src/server.ts
@@ -1,4 +1,4 @@
-import { execSync } from "node:child_process";
+import { exec, execSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -90,6 +90,49 @@ app.post("/api/shutdown", (c) => {
 	// Schedule shutdown after response is sent
 	setTimeout(() => process.exit(0), 500);
 	return c.json({ status: "shutting_down" });
+});
+
+// ── Redeploy endpoint — pull latest code and restart ─────────
+let redeployInProgress = false;
+
+app.get("/api/redeploy/status", (c) => {
+	return c.json({ in_progress: redeployInProgress });
+});
+
+app.post("/api/redeploy", async (c) => {
+	if (redeployInProgress) {
+		return c.json({ error: "Redeploy already in progress" }, 409);
+	}
+	redeployInProgress = true;
+	broadcastSSE("redeploy", { status: "started" });
+
+	const repoDir = process.cwd();
+	const appName = process.env.PM2_APP_NAME || "geo-dashboard";
+
+	// Run deploy steps in background so the response returns immediately
+	const script = [
+		`cd "${repoDir}"`,
+		"git fetch origin main",
+		"git reset --hard origin/main",
+		"npm ci",
+		"npm run build",
+		`pm2 reload ${appName}`,
+	].join(" && ");
+
+	exec(script, { timeout: 300_000 }, (error, stdout, stderr) => {
+		redeployInProgress = false;
+		if (error) {
+			console.error("❌ Redeploy failed:", error.message);
+			console.error(stderr);
+			broadcastSSE("redeploy", { status: "failed", error: error.message, stderr });
+		} else {
+			console.log("✅ Redeploy complete");
+			console.log(stdout);
+			broadcastSSE("redeploy", { status: "completed", stdout });
+		}
+	});
+
+	return c.json({ status: "started", message: "Redeploy initiated. Server will restart shortly." });
 });
 
 // SSE endpoint — real-time pipeline events

--- a/packages/dashboard/src/ui/dashboard.html
+++ b/packages/dashboard/src/ui/dashboard.html
@@ -393,6 +393,14 @@ details.collapsible > .collapsible-content { padding: 16px; }
 	<h1>GEO Agent Dashboard</h1>
 	<div style="display:flex;align-items:center;gap:12px;">
 		<span id="versionInfo" style="font-size:10px;color:var(--text-muted);font-family:monospace;"></span>
+		<button id="redeployBtn" onclick="handleRedeploy()" style="
+			padding:6px 14px;font-size:12px;font-weight:600;
+			background:var(--accent, #2563eb);color:#fff;border:none;border-radius:6px;
+			cursor:pointer;display:flex;align-items:center;gap:6px;
+			transition:opacity 0.2s;
+		" title="Pull latest code and restart server">
+			&#x21bb; Redeploy
+		</button>
 		<div class="status" id="connectionStatus">Connecting...</div>
 	</div>
 </div>
@@ -562,6 +570,26 @@ const API = window.location.origin;
 let targets = [];
 let prompts = [];
 let providers = [];
+
+// ── Redeploy ─────────────────────────────────────────
+async function handleRedeploy() {
+	if (!confirm('Pull latest code from main and restart the server?\n\nThe page will reload automatically after redeploy.')) return;
+	var btn = document.getElementById('redeployBtn');
+	btn.disabled = true;
+	btn.style.opacity = '0.6';
+	btn.innerHTML = '&#x23F3; Deploying...';
+	try {
+		var res = await fetch(API + '/api/redeploy', { method: 'POST' });
+		var data = await res.json();
+		if (!res.ok) { alert('Redeploy failed: ' + (data.error || res.statusText)); resetRedeployBtn(); return; }
+	} catch (e) { alert('Redeploy request failed: ' + e.message); resetRedeployBtn(); return; }
+}
+function resetRedeployBtn() {
+	var btn = document.getElementById('redeployBtn');
+	btn.disabled = false;
+	btn.style.opacity = '1';
+	btn.innerHTML = '&#x21bb; Redeploy';
+}
 
 // ── Navigation (with URL hash persistence) ──────────
 function switchTab(tabName) {
@@ -928,6 +956,17 @@ function initSSE() {
 			var errMsg = '⚠️ LLM errors (' + data.errors.length + '): ' + data.errors[0].slice(0, 100);
 			if (data.errors.length > 1) errMsg += ' (+' + (data.errors.length - 1) + ' more)';
 			toast(errMsg, 8000);
+		});
+
+		sseSource.addEventListener('redeploy', function(e) {
+			var data = JSON.parse(e.data);
+			if (data.status === 'completed') {
+				toast('Redeploy complete! Reloading...', 'success');
+				setTimeout(function() { window.location.reload(); }, 2000);
+			} else if (data.status === 'failed') {
+				toast('Redeploy failed: ' + (data.error || 'Unknown error'), 'error');
+				resetRedeployBtn();
+			}
 		});
 
 		sseSource.onerror = function() {


### PR DESCRIPTION
- POST /api/redeploy 엔드포인트: git fetch + reset --hard origin/main + npm ci + build + pm2 reload
  - GET /api/redeploy/status 엔드포인트: 진행 여부 조회
  - 중복 요청 방지 (409 응답), 타임아웃 5분
  - SSE redeploy 이벤트로 완료/실패 상태 브로드캐스트
  - 대시보드 헤더 우측에 Redeploy 버튼 UI + 완료 시 자동 페이지 리로드
  - authMiddleware 적용으로 인증된 사용자만 실행 가능