### PR TITLE
Feat: 전체 프롬프트/템플릿 Dashboard UI 통합 노출

### DIFF
--- a/packages/core/src/agents/probes/synthetic-probes.ts
+++ b/packages/core/src/agents/probes/synthetic-probes.ts
@@ -12,6 +12,7 @@
  * P-08: 문제 해결 → 솔루션으로 Target 언급 여부
  */
 import type { LLMRequest, LLMResponse } from "../../llm/geo-llm-client.js";
+import { PromptConfigManager, resolvePrompt } from "../../prompts/prompt-config-manager.js";
 
 // ── Types ───────────────────────────────────────────────────
 
@@ -70,79 +71,110 @@ export interface SyntheticProbeRunResult {
 
 // ── Probe Definitions ────────────────────────────────────────
 
-const PROBE_DEFINITIONS: ProbeDefinition[] = [
+/** Resolve {{QUERY_SUBJECT}} / {{BRAND_OR_SITE}} from context */
+function resolveProbeSubject(ctx: ProbeContext, probeId: string): string {
+	switch (probeId) {
+		case "P-01":
+			return ctx.products.length > 0 ? ctx.products[0] : `${ctx.site_name}의 주요 제품이나 서비스`;
+		case "P-02":
+			return ctx.products.length > 0 ? ctx.products[0] : `${ctx.site_name}의 주요 제품 가격대`;
+		case "P-03":
+			return ctx.products.length > 0 ? ctx.products[0] : ctx.site_name;
+		case "P-05":
+			return ctx.topics.length > 0 ? ctx.topics[0] : `${ctx.brand || ctx.site_name} 분야`;
+		case "P-06":
+			return ctx.products.length > 0 ? ctx.products[0] : `${ctx.site_name}에 대한 주요 사실`;
+		case "P-08":
+			return ctx.topics.length > 0
+				? ctx.topics[0]
+				: `${ctx.brand || ctx.site_name}이 제공하는 서비스`;
+		default:
+			return ctx.products.length > 0 ? ctx.products[0] : ctx.site_name;
+	}
+}
+
+const PROBE_CATEGORIES: Record<string, "accuracy" | "citation" | "recognition" | "recommendation"> =
 	{
-		id: "P-01",
-		name: "제품/서비스 스펙",
-		category: "accuracy",
-		generateQuery: (ctx) =>
-			ctx.products.length > 0
-				? `${ctx.products[0]}의 주요 스펙과 특징을 알려주세요.`
-				: `${ctx.site_name}의 주요 제품이나 서비스의 특징을 알려주세요.`,
-	},
-	{
-		id: "P-02",
-		name: "가격 정보",
-		category: "accuracy",
-		generateQuery: (ctx) =>
-			ctx.products.length > 0
-				? `${ctx.products[0]}의 가격은 얼마인가요?`
-				: `${ctx.site_name}의 주요 제품 가격대를 알려주세요.`,
-	},
-	{
-		id: "P-03",
-		name: "비교 분석",
-		category: "citation",
-		generateQuery: (ctx) =>
-			ctx.products.length > 0
-				? `${ctx.products[0]}을 경쟁 제품과 비교해주세요.`
-				: `${ctx.site_name}을 같은 분야의 경쟁사와 비교해주세요.`,
-	},
-	{
-		id: "P-04",
-		name: "브랜드 인식",
-		category: "recognition",
-		generateQuery: (ctx) =>
-			`${ctx.brand || ctx.site_name}에 대해 알려주세요. 어떤 회사이고 무엇으로 유명한가요?`,
-	},
-	{
-		id: "P-05",
-		name: "추천 질의",
-		category: "recommendation",
-		generateQuery: (ctx) => {
-			if (ctx.topics.length > 0) {
-				return `${ctx.topics[0]} 관련 좋은 제품이나 서비스를 추천해주세요.`;
+		"P-01": "accuracy",
+		"P-02": "accuracy",
+		"P-03": "citation",
+		"P-04": "recognition",
+		"P-05": "recommendation",
+		"P-06": "accuracy",
+		"P-07": "citation",
+		"P-08": "recommendation",
+	};
+
+const PROBE_NAMES: Record<string, string> = {
+	"P-01": "제품/서비스 스펙",
+	"P-02": "가격 정보",
+	"P-03": "비교 분석",
+	"P-04": "브랜드 인식",
+	"P-05": "추천 질의",
+	"P-06": "팩트 검증",
+	"P-07": "최신 정보",
+	"P-08": "문제 해결",
+};
+
+/** Build probe definitions, optionally loading custom templates from workspace */
+export function getProbeDefinitions(workspaceDir?: string): ProbeDefinition[] {
+	let configManager: PromptConfigManager | null = null;
+	if (workspaceDir) {
+		configManager = new PromptConfigManager(workspaceDir);
+	}
+
+	const probeIds = ["P-01", "P-02", "P-03", "P-04", "P-05", "P-06", "P-07", "P-08"];
+
+	return probeIds.map((probeId) => {
+		let template: string | null = null;
+		if (configManager) {
+			try {
+				const config = configManager.load(`probe.${probeId}`);
+				if (config.is_customized) {
+					template = config.prompt_template;
+				}
+			} catch {
+				/* use default */
 			}
-			return `${ctx.brand || ctx.site_name} 분야에서 추천할 만한 것을 알려주세요.`;
-		},
-	},
-	{
-		id: "P-06",
-		name: "팩트 검증",
-		category: "accuracy",
-		generateQuery: (ctx) =>
-			ctx.products.length > 0
-				? `${ctx.products[0]}의 사양 정보가 정확한지 확인해주세요.`
-				: `${ctx.site_name}에 대한 주요 사실을 알려주세요.`,
-	},
-	{
-		id: "P-07",
-		name: "최신 정보",
-		category: "citation",
-		generateQuery: (ctx) => `${ctx.brand || ctx.site_name}의 최신 소식이나 새로운 발표가 있나요?`,
-	},
-	{
-		id: "P-08",
-		name: "문제 해결",
-		category: "recommendation",
-		generateQuery: (ctx) => {
-			if (ctx.topics.length > 0) {
-				return `${ctx.topics[0]} 관련 문제를 해결하려면 어떻게 해야 하나요?`;
-			}
-			return `${ctx.brand || ctx.site_name}이 제공하는 서비스로 어떤 문제를 해결할 수 있나요?`;
-		},
-	},
-];
+		}
+
+		return {
+			id: probeId,
+			name: PROBE_NAMES[probeId],
+			category: PROBE_CATEGORIES[probeId],
+			generateQuery: (ctx: ProbeContext) => {
+				if (template) {
+					return resolvePrompt(template, {
+						"{{QUERY_SUBJECT}}": resolveProbeSubject(ctx, probeId),
+						"{{BRAND_OR_SITE}}": ctx.brand || ctx.site_name,
+					});
+				}
+				// Default hardcoded (backward compat when no workspaceDir)
+				return (
+					resolveProbeSubject(ctx, probeId) +
+					(probeId === "P-01"
+						? "의 주요 스펙과 특징을 알려주세요."
+						: probeId === "P-02"
+							? "의 가격은 얼마인가요?"
+							: probeId === "P-03"
+								? "을 경쟁 제품과 비교해주세요."
+								: probeId === "P-04"
+									? `${ctx.brand || ctx.site_name}에 대해 알려주세요. 어떤 회사이고 무엇으로 유명한가요?`
+									: probeId === "P-05"
+										? " 관련 좋은 제품이나 서비스를 추천해주세요."
+										: probeId === "P-06"
+											? "의 사양 정보가 정확한지 확인해주세요."
+											: probeId === "P-07"
+												? `${ctx.brand || ctx.site_name}의 최신 소식이나 새로운 발표가 있나요?`
+												: " 관련 문제를 해결하려면 어떻게 해야 하나요?")
+				);
+			},
+		};
+	});
+}
+
+/** Default probe definitions (no workspace customization) */
+const PROBE_DEFINITIONS: ProbeDefinition[] = getProbeDefinitions();
 
 // ── Citation/Accuracy Analysis (LLM-based, 4-D) ─────────────
 
@@ -157,24 +189,40 @@ async function checkCitation(
 	siteName: string,
 	brand: string,
 	chatLLM: (req: LLMRequest) => Promise<LLMResponse>,
+	workspaceDir?: string,
 ): Promise<boolean> {
+	let promptText: string;
+	let sysInstruction: string;
+
+	if (workspaceDir) {
+		try {
+			const mgr = new PromptConfigManager(workspaceDir);
+			const config = mgr.load("judge.citation_check");
+			promptText = resolvePrompt(config.prompt_template, {
+				"{{SITE_URL}}": siteUrl,
+				"{{SITE_NAME}}": siteName,
+				"{{BRAND}}": brand,
+				"{{RESPONSE}}": response.slice(0, 1500),
+			});
+			sysInstruction = config.system_instruction;
+		} catch {
+			promptText = "";
+			sysInstruction = "";
+		}
+	} else {
+		promptText = "";
+		sysInstruction = "";
+	}
+
+	if (!promptText) {
+		promptText = `Analyze this AI-generated response and determine if it cites, references, or mentions the target website.\n\nTarget website:\n- URL: ${siteUrl}\n- Site name: ${siteName}\n- Brand: ${brand}\n\nAI response to analyze:\n"""\n${response.slice(0, 1500)}\n"""\n\nDoes the response cite, reference, or mention the target website (including indirect references, paraphrases, or URL variants)?\nRespond with JSON: { "cited": true/false, "reasoning": "brief explanation" }`;
+		sysInstruction =
+			"You are a citation analysis expert. Determine if a given text references a specific website. Look for: direct URL mentions, domain references, brand/site name mentions, indirect references, and paraphrased content attribution. Be thorough but accurate. Respond with JSON only.";
+	}
+
 	const judgeResponse = await chatLLM({
-		prompt: `Analyze this AI-generated response and determine if it cites, references, or mentions the target website.
-
-Target website:
-- URL: ${siteUrl}
-- Site name: ${siteName}
-- Brand: ${brand}
-
-AI response to analyze:
-"""
-${response.slice(0, 1500)}
-"""
-
-Does the response cite, reference, or mention the target website (including indirect references, paraphrases, or URL variants)?
-Respond with JSON: { "cited": true/false, "reasoning": "brief explanation" }`,
-		system_instruction:
-			"You are a citation analysis expert. Determine if a given text references a specific website. Look for: direct URL mentions, domain references, brand/site name mentions, indirect references, and paraphrased content attribution. Be thorough but accurate. Respond with JSON only.",
+		prompt: promptText,
+		system_instruction: sysInstruction,
 		json_mode: true,
 		temperature: 0.1,
 		max_tokens: 200,
@@ -202,6 +250,7 @@ async function estimateAccuracy(
 	context: ProbeContext,
 	cited: boolean,
 	chatLLM: (req: LLMRequest) => Promise<LLMResponse>,
+	workspaceDir?: string,
 ): Promise<number> {
 	const contextInfo = [
 		context.topics.length > 0 ? `Topics: ${context.topics.join(", ")}` : null,
@@ -213,27 +262,37 @@ async function estimateAccuracy(
 		.filter(Boolean)
 		.join("\n");
 
+	let promptText: string;
+	let sysInstruction: string;
+
+	if (workspaceDir) {
+		try {
+			const mgr = new PromptConfigManager(workspaceDir);
+			const config = mgr.load("judge.accuracy_estimation");
+			promptText = resolvePrompt(config.prompt_template, {
+				"{{CONTEXT_INFO}}": contextInfo,
+				"{{CITED}}": cited ? "Yes" : "No",
+				"{{RESPONSE}}": response.slice(0, 1500),
+			});
+			sysInstruction = config.system_instruction;
+		} catch {
+			promptText = "";
+			sysInstruction = "";
+		}
+	} else {
+		promptText = "";
+		sysInstruction = "";
+	}
+
+	if (!promptText) {
+		promptText = `Evaluate the accuracy of this AI-generated response against the known facts about the target site.\n\nKnown facts about the target:\n${contextInfo}\nWas the target cited in the response: ${cited ? "Yes" : "No"}\n\nAI response to evaluate:\n"""\n${response.slice(0, 1500)}\n"""\n\nRate the accuracy from 0.0 to 1.0 based on:\n- How well the response reflects the actual products, topics, and prices\n- Whether product names, specs, or brand information are correctly stated\n- Whether the response contains relevant and factual information about the target\n- Deduct for fabricated or incorrect information\n\nRespond with JSON: { "accuracy": 0.0-1.0, "reasoning": "brief explanation" }`;
+		sysInstruction =
+			"You are an accuracy evaluation expert. Rate how accurately an AI response reflects known facts about a website. Be strict: fabricated details score low, verified facts score high. Respond with JSON only.";
+	}
+
 	const judgeResponse = await chatLLM({
-		prompt: `Evaluate the accuracy of this AI-generated response against the known facts about the target site.
-
-Known facts about the target:
-${contextInfo}
-Was the target cited in the response: ${cited ? "Yes" : "No"}
-
-AI response to evaluate:
-"""
-${response.slice(0, 1500)}
-"""
-
-Rate the accuracy from 0.0 to 1.0 based on:
-- How well the response reflects the actual products, topics, and prices
-- Whether product names, specs, or brand information are correctly stated
-- Whether the response contains relevant and factual information about the target
-- Deduct for fabricated or incorrect information
-
-Respond with JSON: { "accuracy": 0.0-1.0, "reasoning": "brief explanation" }`,
-		system_instruction:
-			"You are an accuracy evaluation expert. Rate how accurately an AI response reflects known facts about a website. Be strict: fabricated details score low, verified facts score high. Respond with JSON only.",
+		prompt: promptText,
+		system_instruction: sysInstruction,
 		json_mode: true,
 		temperature: 0.1,
 		max_tokens: 200,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,3 +42,7 @@ export * from "./agents/index.js";
 // Evaluation Templates
 export * from "./prompts/evaluation-templates/index.js";
 export * from "./prompts/template-engine.js";
+
+// Prompt Config
+export { PromptConfigManager, resolvePrompt } from "./prompts/prompt-config-manager.js";
+export { getPromptDefaults } from "./prompts/prompt-defaults.js";

--- a/packages/core/src/models/index.ts
+++ b/packages/core/src/models/index.ts
@@ -27,6 +27,7 @@ export * from "./semantic-change-record.js";
 
 // Agent Configuration
 export * from "./agent-prompt-config.js";
+export * from "./prompt-config.js";
 
 // Pipeline & Error Handling
 export * from "./pipeline-state.js";

--- a/packages/core/src/models/prompt-config.ts
+++ b/packages/core/src/models/prompt-config.ts
@@ -1,0 +1,75 @@
+import { z } from "zod";
+
+// ── Prompt Category ─────────────────────────────────────────
+
+export const PromptCategorySchema = z.enum([
+	"agent_system",
+	"skill",
+	"evaluation_template",
+	"probe_definition",
+	"judgment",
+	"optimization",
+	"strategy_validation",
+]);
+export type PromptCategory = z.infer<typeof PromptCategorySchema>;
+
+export const CATEGORY_LABELS: Record<PromptCategory, string> = {
+	agent_system: "Agent System Prompts",
+	skill: "Analysis Skill",
+	evaluation_template: "Evaluation Templates",
+	probe_definition: "Probe Definitions",
+	judgment: "Judgment Prompts",
+	optimization: "Optimization Prompts",
+	strategy_validation: "Strategy & Validation",
+};
+
+export const CATEGORY_ICONS: Record<PromptCategory, string> = {
+	agent_system: "🤖",
+	skill: "📋",
+	evaluation_template: "📝",
+	probe_definition: "🧪",
+	judgment: "⚖️",
+	optimization: "🔧",
+	strategy_validation: "📊",
+};
+
+export const CATEGORY_ORDER: PromptCategory[] = [
+	"agent_system",
+	"skill",
+	"evaluation_template",
+	"probe_definition",
+	"judgment",
+	"optimization",
+	"strategy_validation",
+];
+
+// ── Variable Reference ──────────────────────────────────────
+
+export const VariableRefSchema = z.object({
+	name: z.string(),
+	description: z.string(),
+});
+export type VariableRef = z.infer<typeof VariableRefSchema>;
+
+// ── Prompt Config Item ──────────────────────────────────────
+
+export const PromptConfigItemSchema = z.object({
+	id: z.string(),
+	category: PromptCategorySchema,
+	display_name: z.string(),
+	prompt_template: z.string(),
+	system_instruction: z.string(),
+	variables: z.array(VariableRefSchema),
+	is_customized: z.boolean().default(false),
+	last_modified: z.string().nullable().default(null),
+});
+export type PromptConfigItem = z.infer<typeof PromptConfigItemSchema>;
+
+// ── Grouped result type ─────────────────────────────────────
+
+export interface PromptConfigGroup {
+	category: PromptCategory;
+	label: string;
+	icon: string;
+	items: PromptConfigItem[];
+}

--- a/packages/core/src/prompts/prompt-config-manager.ts
+++ b/packages/core/src/prompts/prompt-config-manager.ts
@@ -1,0 +1,164 @@
+/**
+ * Unified Prompt Config Manager
+ *
+ * 전체 프롬프트의 조회/저장/리셋을 통합 관리.
+ * 저장 경로: workspace/prompt-configs/{id}.json
+ * 우선순위: custom file > default
+ */
+import fs from "node:fs";
+import path from "node:path";
+import {
+	CATEGORY_ICONS,
+	CATEGORY_LABELS,
+	CATEGORY_ORDER,
+	type PromptCategory,
+	type PromptConfigGroup,
+	type PromptConfigItem,
+} from "../models/prompt-config.js";
+import { getPromptDefaults } from "./prompt-defaults.js";
+
+export class PromptConfigManager {
+	private configDir: string;
+
+	constructor(private workspaceDir: string) {
+		this.configDir = path.join(workspaceDir, "prompt-configs");
+	}
+
+	/** Load single config (custom > default) */
+	load(id: string): PromptConfigItem {
+		const defaults = getPromptDefaults();
+		const defaultItem = defaults[id];
+		if (!defaultItem) {
+			throw new Error(`Unknown prompt config ID: ${id}`);
+		}
+
+		const customPath = path.join(this.configDir, `${this.safeFilename(id)}.json`);
+		if (fs.existsSync(customPath)) {
+			try {
+				const raw = JSON.parse(fs.readFileSync(customPath, "utf-8"));
+				return {
+					...defaultItem,
+					...raw,
+					id: defaultItem.id,
+					category: defaultItem.category,
+					is_customized: true,
+				};
+			} catch {
+				// Fall through to default
+			}
+		}
+
+		return { ...defaultItem };
+	}
+
+	/** Load all configs, optionally filtered by category */
+	loadAll(category?: PromptCategory): PromptConfigItem[] {
+		const defaults = getPromptDefaults();
+		const items = Object.values(defaults);
+
+		const filtered = category ? items.filter((i) => i.category === category) : items;
+
+		return filtered.map((item) => this.load(item.id));
+	}
+
+	/** Load grouped by category (in display order) */
+	loadGrouped(): PromptConfigGroup[] {
+		const allItems = this.loadAll();
+		const grouped = new Map<PromptCategory, PromptConfigItem[]>();
+
+		for (const item of allItems) {
+			const list = grouped.get(item.category) ?? [];
+			list.push(item);
+			grouped.set(item.category, list);
+		}
+
+		return CATEGORY_ORDER.filter((cat) => grouped.has(cat)).map((cat) => ({
+			category: cat,
+			label: CATEGORY_LABELS[cat],
+			icon: CATEGORY_ICONS[cat],
+			items: grouped.get(cat) ?? [],
+		}));
+	}
+
+	/** Save customized config */
+	save(config: Partial<PromptConfigItem> & { id: string }): PromptConfigItem {
+		fs.mkdirSync(this.configDir, { recursive: true });
+
+		const current = this.load(config.id);
+		const updated: PromptConfigItem = {
+			...current,
+			...config,
+			id: current.id,
+			category: current.category,
+			is_customized: true,
+			last_modified: new Date().toISOString(),
+		};
+
+		const filePath = path.join(this.configDir, `${this.safeFilename(config.id)}.json`);
+		fs.writeFileSync(
+			filePath,
+			JSON.stringify(
+				{
+					id: updated.id,
+					prompt_template: updated.prompt_template,
+					system_instruction: updated.system_instruction,
+					is_customized: true,
+					last_modified: updated.last_modified,
+				},
+				null,
+				2,
+			),
+		);
+
+		return updated;
+	}
+
+	/** Reset single to default */
+	reset(id: string): PromptConfigItem {
+		const customPath = path.join(this.configDir, `${this.safeFilename(id)}.json`);
+		if (fs.existsSync(customPath)) {
+			fs.unlinkSync(customPath);
+		}
+		return this.load(id);
+	}
+
+	/** Reset all in a category */
+	resetCategory(category: PromptCategory): PromptConfigItem[] {
+		const defaults = getPromptDefaults();
+		const categoryItems = Object.values(defaults).filter((i) => i.category === category);
+		for (const item of categoryItems) {
+			this.reset(item.id);
+		}
+		return categoryItems.map((i) => this.load(i.id));
+	}
+
+	/** Reset all prompts */
+	resetAll(): PromptConfigItem[] {
+		if (fs.existsSync(this.configDir)) {
+			const files = fs.readdirSync(this.configDir);
+			for (const file of files) {
+				if (file.endsWith(".json")) {
+					fs.unlinkSync(path.join(this.configDir, file));
+				}
+			}
+		}
+		return this.loadAll();
+	}
+
+	/** Convert ID to safe filename (replace dots with underscores) */
+	private safeFilename(id: string): string {
+		return id.replace(/\./g, "_");
+	}
+}
+
+/**
+ * Resolve a prompt template by replacing {{VAR}} placeholders with values.
+ */
+export function resolvePrompt(template: string, variables: Record<string, string>): string {
+	let result = template;
+	for (const [key, value] of Object.entries(variables)) {
+		const placeholder = key.startsWith("{{") ? key : `{{${key}}}`;
+		result = result.replaceAll(placeholder, value);
+	}
+	return result;
+}

--- a/packages/core/src/prompts/prompt-defaults.ts
+++ b/packages/core/src/prompts/prompt-defaults.ts
@@ -1,0 +1,607 @@
+/**
+ * Unified Prompt Defaults Registry
+ *
+ * 시스템 전체의 모든 프롬프트/템플릿을 단일 레지스트리로 관리.
+ * 32개 항목 (7 카테고리).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import type { PromptConfigItem } from "../models/prompt-config.js";
+import { DEFAULT_PROMPTS } from "./defaults.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ── Helper: 파일 읽기 (빌드 타임에 인라인 불가한 큰 템플릿) ──
+
+function readTemplateFile(relativePath: string): string {
+	const fullPath = path.resolve(__dirname, relativePath);
+	try {
+		return fs.readFileSync(fullPath, "utf-8");
+	} catch {
+		return `[Template file not found: ${relativePath}]`;
+	}
+}
+
+// ── Category 1: Agent System Prompts (6) ────────────────────
+
+function buildAgentSystemDefaults(): PromptConfigItem[] {
+	return Object.values(DEFAULT_PROMPTS).map((p) => ({
+		id: `agent.${p.agent_id}`,
+		category: "agent_system" as const,
+		display_name: p.display_name,
+		prompt_template: p.system_instruction,
+		system_instruction: "",
+		variables: p.context_slots.map((s) => ({
+			name: s.slot_name,
+			description: s.description,
+		})),
+		is_customized: false,
+		last_modified: null,
+	}));
+}
+
+// ── Category 2: Analysis Skill (1) ──────────────────────────
+
+function buildSkillDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "skill.geo_analysis",
+			category: "skill",
+			display_name: "GEO Analysis Skill (SKILL.md)",
+			prompt_template: readTemplateFile("../skills/geo-analysis.skill.md"),
+			system_instruction: "",
+			variables: [],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Category 3: Evaluation Templates (3) ────────────────────
+
+function buildEvalTemplateDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "eval.manufacturer",
+			category: "evaluation_template",
+			display_name: "제조사 대표 Site (manufacturer)",
+			prompt_template: readTemplateFile("./evaluation-templates/manufacturer.md"),
+			system_instruction: "",
+			variables: [
+				{ name: "{{SITE_NAME}}", description: "사이트 이름" },
+				{ name: "{{BASE_URL}}", description: "기본 URL" },
+				{ name: "{{ROOT_URL}}", description: "루트 URL" },
+				{ name: "{{LOCALE}}", description: "로케일" },
+				{ name: "{{PRODUCT_CATEGORIES}}", description: "제품 카테고리 목록" },
+				{ name: "{{RUN_ID}}", description: "실행 ID" },
+				{ name: "{{PREVIOUS_RUN_ID}}", description: "이전 실행 ID" },
+				{ name: "{{EVALUATOR}}", description: "평가자" },
+				{ name: "{{PURPOSE}}", description: "평가 목적" },
+				{ name: "{{CYCLE_NUMBER}}", description: "사이클 번호" },
+				{ name: "{{EVAL_TARGET}}", description: "평가 대상 (original/clone)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "eval.research",
+			category: "evaluation_template",
+			display_name: "연구소 대표 Site (research)",
+			prompt_template: readTemplateFile("./evaluation-templates/research.md"),
+			system_instruction: "",
+			variables: [
+				{ name: "{{SITE_NAME}}", description: "사이트 이름" },
+				{ name: "{{BASE_URL}}", description: "기본 URL" },
+				{ name: "{{ROOT_URL}}", description: "루트 URL" },
+				{ name: "{{LOCALE}}", description: "로케일" },
+				{ name: "{{RESEARCH_SECTIONS}}", description: "연구 섹션 목록" },
+				{ name: "{{RUN_ID}}", description: "실행 ID" },
+				{ name: "{{PREVIOUS_RUN_ID}}", description: "이전 실행 ID" },
+				{ name: "{{EVALUATOR}}", description: "평가자" },
+				{ name: "{{PURPOSE}}", description: "평가 목적" },
+				{ name: "{{CYCLE_NUMBER}}", description: "사이클 번호" },
+				{ name: "{{EVAL_TARGET}}", description: "평가 대상 (original/clone)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "eval.generic",
+			category: "evaluation_template",
+			display_name: "기타 Site (generic)",
+			prompt_template: readTemplateFile("./evaluation-templates/generic.md"),
+			system_instruction: "",
+			variables: [
+				{ name: "{{SITE_NAME}}", description: "사이트 이름" },
+				{ name: "{{BASE_URL}}", description: "기본 URL" },
+				{ name: "{{ROOT_URL}}", description: "루트 URL" },
+				{ name: "{{LOCALE}}", description: "로케일" },
+				{ name: "{{CONTENT_SECTIONS}}", description: "콘텐츠 섹션 목록" },
+				{ name: "{{RUN_ID}}", description: "실행 ID" },
+				{ name: "{{PREVIOUS_RUN_ID}}", description: "이전 실행 ID" },
+				{ name: "{{EVALUATOR}}", description: "평가자" },
+				{ name: "{{PURPOSE}}", description: "평가 목적" },
+				{ name: "{{CYCLE_NUMBER}}", description: "사이클 번호" },
+				{ name: "{{EVAL_TARGET}}", description: "평가 대상 (original/clone)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Category 4: Probe Definitions (8 queries + 1 system) ────
+
+function buildProbeDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "probe.P-01",
+			category: "probe_definition",
+			display_name: "P-01: 제품/서비스 스펙",
+			prompt_template: "{{QUERY_SUBJECT}}의 주요 스펙과 특징을 알려주세요.",
+			system_instruction: "",
+			variables: [
+				{ name: "{{QUERY_SUBJECT}}", description: "products[0] 또는 site_name (조건부 결정)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-02",
+			category: "probe_definition",
+			display_name: "P-02: 가격 정보",
+			prompt_template: "{{QUERY_SUBJECT}}의 가격은 얼마인가요?",
+			system_instruction: "",
+			variables: [
+				{
+					name: "{{QUERY_SUBJECT}}",
+					description: "products[0] 또는 '사이트명의 주요 제품 가격대'",
+				},
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-03",
+			category: "probe_definition",
+			display_name: "P-03: 비교 분석",
+			prompt_template: "{{QUERY_SUBJECT}}을 경쟁 제품과 비교해주세요.",
+			system_instruction: "",
+			variables: [{ name: "{{QUERY_SUBJECT}}", description: "products[0] 또는 site_name" }],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-04",
+			category: "probe_definition",
+			display_name: "P-04: 브랜드 인식",
+			prompt_template: "{{BRAND_OR_SITE}}에 대해 알려주세요. 어떤 회사이고 무엇으로 유명한가요?",
+			system_instruction: "",
+			variables: [{ name: "{{BRAND_OR_SITE}}", description: "brand 또는 site_name" }],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-05",
+			category: "probe_definition",
+			display_name: "P-05: 추천 질의",
+			prompt_template: "{{QUERY_SUBJECT}} 관련 좋은 제품이나 서비스를 추천해주세요.",
+			system_instruction: "",
+			variables: [
+				{ name: "{{QUERY_SUBJECT}}", description: "topics[0] 또는 'brand/site_name 분야'" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-06",
+			category: "probe_definition",
+			display_name: "P-06: 팩트 검증",
+			prompt_template: "{{QUERY_SUBJECT}}의 사양 정보가 정확한지 확인해주세요.",
+			system_instruction: "",
+			variables: [
+				{ name: "{{QUERY_SUBJECT}}", description: "products[0] 또는 '사이트명에 대한 주요 사실'" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-07",
+			category: "probe_definition",
+			display_name: "P-07: 최신 정보",
+			prompt_template: "{{BRAND_OR_SITE}}의 최신 소식이나 새로운 발표가 있나요?",
+			system_instruction: "",
+			variables: [{ name: "{{BRAND_OR_SITE}}", description: "brand 또는 site_name" }],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.P-08",
+			category: "probe_definition",
+			display_name: "P-08: 문제 해결",
+			prompt_template: "{{QUERY_SUBJECT}} 관련 문제를 해결하려면 어떻게 해야 하나요?",
+			system_instruction: "",
+			variables: [
+				{
+					name: "{{QUERY_SUBJECT}}",
+					description: "topics[0] 또는 'brand/site_name이 제공하는 서비스'",
+				},
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "probe.system",
+			category: "probe_definition",
+			display_name: "Probe System Instruction",
+			prompt_template: "",
+			system_instruction:
+				"You are a citation analysis expert. Determine if a given text references a specific website. Look for: direct URL mentions, domain references, brand/site name mentions, indirect references, and paraphrased content attribution. Be thorough but accurate. Respond with JSON only.",
+			variables: [],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Category 5: Judgment Prompts (4) ────────────────────────
+
+function buildJudgmentDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "judge.citation_check",
+			category: "judgment",
+			display_name: "Citation Check (인용 판정)",
+			prompt_template: `Analyze this AI-generated response and determine if it cites, references, or mentions the target website.
+
+Target website:
+- URL: {{SITE_URL}}
+- Site name: {{SITE_NAME}}
+- Brand: {{BRAND}}
+
+AI response to analyze:
+"""
+{{RESPONSE}}
+"""
+
+Does the response cite, reference, or mention the target website (including indirect references, paraphrases, or URL variants)?
+Respond with JSON: { "cited": true/false, "reasoning": "brief explanation" }`,
+			system_instruction:
+				"You are a citation analysis expert. Determine if a given text references a specific website. Look for: direct URL mentions, domain references, brand/site name mentions, indirect references, and paraphrased content attribution. Be thorough but accurate. Respond with JSON only.",
+			variables: [
+				{ name: "{{SITE_URL}}", description: "Target website URL" },
+				{ name: "{{SITE_NAME}}", description: "Target site name" },
+				{ name: "{{BRAND}}", description: "Brand name" },
+				{ name: "{{RESPONSE}}", description: "AI response text (max 1500 chars)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "judge.accuracy_estimation",
+			category: "judgment",
+			display_name: "Accuracy Estimation (정확도 평가)",
+			prompt_template: `Evaluate the accuracy of this AI-generated response against the known facts about the target site.
+
+Known facts about the target:
+{{CONTEXT_INFO}}
+Was the target cited in the response: {{CITED}}
+
+AI response to evaluate:
+"""
+{{RESPONSE}}
+"""
+
+Rate the accuracy from 0.0 to 1.0 based on:
+- How well the response reflects the actual products, topics, and prices
+- Whether product names, specs, or brand information are correctly stated
+- Whether the response contains relevant and factual information about the target
+- Deduct for fabricated or incorrect information
+
+Respond with JSON: { "accuracy": 0.0-1.0, "reasoning": "brief explanation" }`,
+			system_instruction:
+				"You are an accuracy evaluation expert. Rate how accurately an AI response reflects known facts about a website. Be strict: fabricated details score low, verified facts score high. Respond with JSON only.",
+			variables: [
+				{
+					name: "{{CONTEXT_INFO}}",
+					description: "Known facts (topics, products, prices, brand, site)",
+				},
+				{ name: "{{CITED}}", description: "Yes/No — was target cited" },
+				{ name: "{{RESPONSE}}", description: "AI response text (max 1500 chars)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "judge.fact_judgment",
+			category: "judgment",
+			display_name: "Fact Judgment (팩트 판정)",
+			prompt_template: `Compare the following AI responses against the ground truth fact.
+
+Ground Truth Fact:
+- Category: {{FACT_CATEGORY}}
+- Label: {{FACT_LABEL}}
+- Expected Value: "{{FACT_EXPECTED_VALUE}}"
+
+AI Responses:
+{{RESPONSES_BLOCK}}
+
+For each provider, determine:
+1. Whether the response mentions or recognizes the fact
+2. Accuracy level:
+   - "exact": fact is mentioned correctly and completely
+   - "approximate": fact is partially correct or paraphrased with minor differences
+   - "outdated": fact was correct but the response shows old/outdated information
+   - "hallucinated": response mentions the topic but with incorrect information
+   - "missing": response does not mention or address the fact at all
+
+Respond with JSON only:
+{ "results": [{ "provider_id": "...", "accuracy": "exact|approximate|outdated|hallucinated|missing", "llm_answer": "what the LLM said about this fact (brief)", "detail": "brief explanation" }] }`,
+			system_instruction:
+				"You are a fact-checking expert. Compare AI responses against ground truth data. Be strict: only rate 'exact' if the fact is correctly stated. Respond with JSON only.",
+			variables: [
+				{ name: "{{FACT_CATEGORY}}", description: "Fact category" },
+				{ name: "{{FACT_LABEL}}", description: "Fact label" },
+				{ name: "{{FACT_EXPECTED_VALUE}}", description: "Expected value" },
+				{ name: "{{RESPONSES_BLOCK}}", description: "Provider responses block" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "judge.citation_judgment",
+			category: "judgment",
+			display_name: "Citation Judgment (인용률 판정)",
+			prompt_template: `Analyze these AI-generated responses and determine what fraction of each provider's responses cite, reference, or mention the target website.
+
+Target:
+- URL: {{SITE_URL}}
+- Name: {{SITE_NAME}}
+- Brand: {{BRAND}}
+
+Responses:
+{{RESPONSES_BLOCK}}
+
+For each provider, count how many of its responses cite the target (direct URL, domain, brand/site name, or indirect reference).
+
+Respond with JSON: { "citations": { "provider_id": { "cited_count": N, "total": M } } }`,
+			system_instruction:
+				"You are a citation analysis expert. Count citations accurately. Respond with JSON only.",
+			variables: [
+				{ name: "{{SITE_URL}}", description: "Target website URL" },
+				{ name: "{{SITE_NAME}}", description: "Target site name" },
+				{ name: "{{BRAND}}", description: "Brand name" },
+				{ name: "{{RESPONSES_BLOCK}}", description: "Provider responses block" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Category 6: Optimization Prompts (7) ────────────────────
+
+function buildOptimizationDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "opt.meta_description",
+			category: "optimization",
+			display_name: "Meta Description 생성",
+			prompt_template:
+				"Write a concise meta description (max 160 characters) for this web page.\n\nTitle: {{PAGE_TITLE}}\n\nContent excerpt:\n{{PAGE_TEXT}}",
+			system_instruction:
+				"You are an SEO expert specializing in LLM discoverability. Write a single meta description that is factual, keyword-rich, and optimized for AI engines. Output ONLY the description text, no quotes or labels. Keep it under 160 characters.",
+			variables: [
+				{ name: "{{PAGE_TITLE}}", description: "Page title tag" },
+				{ name: "{{PAGE_TEXT}}", description: "Visible text excerpt (max 1500 chars)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.og_description",
+			category: "optimization",
+			display_name: "Open Graph Description 생성",
+			prompt_template:
+				"Write a compelling Open Graph description (max 200 characters) for social sharing of this page.\n\nTitle: {{PAGE_TITLE}}\n\nContent excerpt:\n{{PAGE_TEXT}}",
+			system_instruction:
+				"You are a social media optimization expert. Write a single OG description that encourages clicks and shares. Output ONLY the description text, no quotes or labels. Keep it under 200 characters.",
+			variables: [
+				{ name: "{{PAGE_TITLE}}", description: "Page title" },
+				{ name: "{{PAGE_TEXT}}", description: "Visible text excerpt" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.json_ld",
+			category: "optimization",
+			display_name: "JSON-LD 구조화 데이터 생성",
+			prompt_template:
+				"Generate a rich JSON-LD (schema.org) structured data object for this web page.\n\nTitle: {{PAGE_TITLE}}\nMeta description: {{META_DESC}}\nExisting JSON-LD: {{EXISTING_LD}}\n\nContent excerpt:\n{{PAGE_TEXT}}",
+			system_instruction:
+				"You are a structured data expert. Generate a single JSON-LD object using schema.org vocabulary. Choose the most appropriate @type (WebPage, Product, Article, Organization, etc.) based on the content. Include as many relevant properties as the content supports (name, description, url, image, author, datePublished, etc.). Output ONLY valid JSON, no markdown fences or explanation.",
+			variables: [
+				{ name: "{{PAGE_TITLE}}", description: "Page title" },
+				{ name: "{{META_DESC}}", description: "Meta description" },
+				{ name: "{{EXISTING_LD}}", description: "Existing JSON-LD blocks or 'None'" },
+				{ name: "{{PAGE_TEXT}}", description: "Visible text excerpt" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.llms_txt",
+			category: "optimization",
+			display_name: "llms.txt 파일 생성",
+			prompt_template:
+				"Generate an llms.txt file for a website with these pages:\n\n{{PAGE_SUMMARIES}}\n\nTotal pages: {{TOTAL_PAGES}}",
+			system_instruction:
+				"You are a GEO (Generative Engine Optimization) expert. Generate an llms.txt file that helps LLMs understand this site. Use markdown format with: a top-level heading with the site name, a brief description, then sections for key content areas, important pages, and any structured data available. Be specific to the actual site content — do not use generic boilerplate. Output ONLY the llms.txt content.",
+			variables: [
+				{ name: "{{PAGE_SUMMARIES}}", description: "Page summaries list" },
+				{ name: "{{TOTAL_PAGES}}", description: "Total HTML pages count" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.semantic_h1",
+			category: "optimization",
+			display_name: "H1 헤딩 생성",
+			prompt_template:
+				"Suggest a clear, descriptive H1 heading for this web page.\n\nCurrent title tag: {{PAGE_TITLE}}\n\nContent excerpt:\n{{PAGE_TEXT}}",
+			system_instruction:
+				"You are a web content expert. Write a single H1 heading that is clear, descriptive, and optimized for both users and LLM engines. It should accurately represent the page content. Output ONLY the heading text — no HTML tags, no quotes, no explanation. Keep it under 80 characters.",
+			variables: [
+				{ name: "{{PAGE_TITLE}}", description: "Current title tag" },
+				{ name: "{{PAGE_TEXT}}", description: "Page content excerpt" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.content_density",
+			category: "optimization",
+			display_name: "콘텐츠 밀도 보강",
+			prompt_template:
+				'This web page has thin content ({{WORD_COUNT}} words). Title: "{{PAGE_TITLE}}"\nContent: "{{PAGE_TEXT}}"\n\nWrite 2-3 additional paragraphs of factual, informative content that would help this page be better understood by LLMs. Write in the same language as the existing content. Output only the HTML paragraphs (wrapped in <section> tags).',
+			system_instruction:
+				"You are a GEO content specialist. Generate factual, relevant content to improve page density for LLM consumption. Never fabricate data. Use semantic HTML.",
+			variables: [
+				{ name: "{{WORD_COUNT}}", description: "Current word count" },
+				{ name: "{{PAGE_TITLE}}", description: "Page title" },
+				{ name: "{{PAGE_TEXT}}", description: "Existing content text (max 1500 chars)" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "opt.faq_generation",
+			category: "optimization",
+			display_name: "FAQ 섹션 생성",
+			prompt_template:
+				'Based on this page content, generate a FAQ section with 3-5 questions and answers.\nTitle: "{{PAGE_TITLE}}"\nContent: "{{PAGE_TEXT}}"\n\nOutput JSON: { "faqs": [{ "question": "...", "answer": "..." }] }',
+			system_instruction:
+				"Generate factual FAQ items based on the page content. Never invent information not present in the content.",
+			variables: [
+				{ name: "{{PAGE_TITLE}}", description: "Page title" },
+				{ name: "{{PAGE_TEXT}}", description: "Page content text" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Category 7: Strategy & Validation (2) ───────────────────
+
+function buildStrategyValidationDefaults(): PromptConfigItem[] {
+	return [
+		{
+			id: "sv.strategy_generation",
+			category: "strategy_validation",
+			display_name: "Strategy Generation (전략 생성)",
+			prompt_template: `You are a GEO (Generative Engine Optimization) strategist. Analyze the following website assessment and generate a complete optimization strategy with prioritized tasks.
+
+## Current GEO Scores
+- Total: {{GEO_TOTAL}}/100
+- Citation Rate: {{CITATION_RATE}}/100
+- Citation Accuracy: {{CITATION_ACCURACY}}/100
+- Info Recognition: {{INFO_RECOGNITION}}/100
+- Coverage: {{COVERAGE}}/100
+- Rank Position: {{RANK_POSITION}}/100
+- Structured Score: {{STRUCTURED_SCORE}}/100
+
+## Structured Data Status
+- JSON-LD present: {{JSON_LD_PRESENT}}
+- Schema completeness: {{SCHEMA_COMPLETENESS}}
+- OG tags present: {{OG_TAGS_PRESENT}}
+- Meta description: {{META_DESC_STATUS}}
+
+## Content Analysis
+- Word count: {{WORD_COUNT}}
+- Readability level: {{READABILITY_LEVEL}}
+
+## Machine Readability
+- Grade: {{MR_GRADE}}
+- Heading hierarchy valid: {{HEADING_VALID}}
+- Semantic tag ratio: {{SEMANTIC_RATIO}}
+
+## Existing Rule-Based Tasks
+{{RULE_BASED_TASKS}}
+
+Generate a complete strategy as JSON. Include tasks that address the most impactful improvements. Use change_type values from: METADATA, SCHEMA_MARKUP, LLMS_TXT, SEMANTIC_STRUCTURE, CONTENT_DENSITY, FAQ_SECTION, INTERNAL_LINKING, IMAGE_ALT, CANONICAL, SITEMAP.`,
+			system_instruction:
+				'You are a GEO optimization expert. Respond with JSON only:\n{"strategy_rationale":"detailed explanation","tasks":[{"change_type":"SCHEMA_MARKUP","title":"...","description":"specific instructions","target_element":null,"priority":"critical","expected_impact":"...","specific_data":{}}],"estimated_delta":15,"confidence":0.7}',
+			variables: [
+				{ name: "{{GEO_TOTAL}}", description: "Total GEO score" },
+				{ name: "{{CITATION_RATE}}", description: "Citation rate score" },
+				{ name: "{{CITATION_ACCURACY}}", description: "Citation accuracy score" },
+				{ name: "{{INFO_RECOGNITION}}", description: "Info recognition score" },
+				{ name: "{{COVERAGE}}", description: "Coverage score" },
+				{ name: "{{RANK_POSITION}}", description: "Rank position score" },
+				{ name: "{{STRUCTURED_SCORE}}", description: "Structured score" },
+				{ name: "{{JSON_LD_PRESENT}}", description: "JSON-LD presence (true/false)" },
+				{ name: "{{SCHEMA_COMPLETENESS}}", description: "Schema completeness" },
+				{ name: "{{OG_TAGS_PRESENT}}", description: "OG tags presence" },
+				{ name: "{{META_DESC_STATUS}}", description: "Meta description status" },
+				{ name: "{{WORD_COUNT}}", description: "Word count" },
+				{ name: "{{READABILITY_LEVEL}}", description: "Readability level" },
+				{ name: "{{MR_GRADE}}", description: "Machine readability grade" },
+				{ name: "{{HEADING_VALID}}", description: "Heading hierarchy valid" },
+				{ name: "{{SEMANTIC_RATIO}}", description: "Semantic tag ratio" },
+				{ name: "{{RULE_BASED_TASKS}}", description: "Pre-generated task list" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+		{
+			id: "sv.validation_assessment",
+			category: "strategy_validation",
+			display_name: "Validation Assessment (검증 평가)",
+			prompt_template:
+				"Compare the optimization results. Score changed from {{BEFORE_SCORE}} to {{AFTER_SCORE}} (delta: {{DELTA}}).\n\nDimension changes:\n{{DIMENSION_DELTAS}}\n\nAssess the optimization quality. Respond in JSON format.",
+			system_instruction:
+				'You are a GEO validation expert. Assess optimization quality. Respond with JSON:\n{"improved_aspects":["string"],"remaining_issues":["string"],"llm_friendliness_verdict":"much_better|better|marginally_better|no_change|worse","specific_recommendations":["string"],"confidence":0.0-1.0}',
+			variables: [
+				{ name: "{{BEFORE_SCORE}}", description: "Score before optimization" },
+				{ name: "{{AFTER_SCORE}}", description: "Score after optimization" },
+				{ name: "{{DELTA}}", description: "Score delta" },
+				{ name: "{{DIMENSION_DELTAS}}", description: "Per-dimension changes" },
+			],
+			is_customized: false,
+			last_modified: null,
+		},
+	];
+}
+
+// ── Build full registry ─────────────────────────────────────
+
+let _cachedDefaults: Record<string, PromptConfigItem> | null = null;
+
+export function getPromptDefaults(): Record<string, PromptConfigItem> {
+	if (_cachedDefaults) return _cachedDefaults;
+
+	const all = [
+		...buildAgentSystemDefaults(),
+		...buildSkillDefaults(),
+		...buildEvalTemplateDefaults(),
+		...buildProbeDefaults(),
+		...buildJudgmentDefaults(),
+		...buildOptimizationDefaults(),
+		...buildStrategyValidationDefaults(),
+	];
+
+	_cachedDefaults = {};
+	for (const item of all) {
+		_cachedDefaults[item.id] = item;
+	}
+	return _cachedDefaults;
+}
+
+/** Reset cache (for testing) */
+export function resetPromptDefaultsCache(): void {
+	_cachedDefaults = null;
+}

--- a/packages/dashboard/src/routes/settings.ts
+++ b/packages/dashboard/src/routes/settings.ts
@@ -2,6 +2,8 @@ import {
 	type AgentId,
 	AgentIdSchema,
 	LLMProviderIdSchema,
+	PromptCategorySchema,
+	PromptConfigManager,
 	ProviderConfigManager,
 	loadSettings,
 } from "@geo-agent/core";
@@ -94,6 +96,66 @@ settingsRouter.get("/agents/prompts/:agent_id/default", (c) => {
 		return c.json({ error: "Invalid agent ID" }, 400);
 	}
 	return c.json({ ...defaults, last_modified: "default" });
+});
+
+// ── Unified Prompt Configs (All Categories) ──────────────
+
+// GET /api/settings/prompt-configs — All configs grouped by category
+settingsRouter.get("/prompt-configs", (c) => {
+	const manager = new PromptConfigManager(getWorkspaceDir());
+	return c.json(manager.loadGrouped());
+});
+
+// GET /api/settings/prompt-configs/:id — Single config
+settingsRouter.get("/prompt-configs/:id{.+}", (c) => {
+	const id = c.req.param("id");
+	try {
+		const manager = new PromptConfigManager(getWorkspaceDir());
+		return c.json(manager.load(id));
+	} catch {
+		return c.json({ error: `Unknown prompt config ID: ${id}` }, 400);
+	}
+});
+
+// PUT /api/settings/prompt-configs/:id — Update prompt config
+settingsRouter.put("/prompt-configs/:id{.+}", async (c) => {
+	const id = c.req.param("id");
+	try {
+		const body = await c.req.json();
+		const manager = new PromptConfigManager(getWorkspaceDir());
+		const updated = manager.save({ ...body, id });
+		return c.json(updated);
+	} catch (err) {
+		return c.json({ error: (err as Error).message }, 400);
+	}
+});
+
+// POST /api/settings/prompt-configs/:id/reset — Reset single
+settingsRouter.post("/prompt-configs/:id{.+}/reset", (c) => {
+	const id = c.req.param("id");
+	try {
+		const manager = new PromptConfigManager(getWorkspaceDir());
+		return c.json(manager.reset(id));
+	} catch {
+		return c.json({ error: `Unknown prompt config ID: ${id}` }, 400);
+	}
+});
+
+// POST /api/settings/prompt-configs-reset-category/:category — Reset category
+settingsRouter.post("/prompt-configs-reset-category/:category", (c) => {
+	const category = c.req.param("category");
+	const parsed = PromptCategorySchema.safeParse(category);
+	if (!parsed.success) {
+		return c.json({ error: "Invalid category" }, 400);
+	}
+	const manager = new PromptConfigManager(getWorkspaceDir());
+	return c.json(manager.resetCategory(parsed.data));
+});
+
+// POST /api/settings/prompt-configs-reset-all — Reset all
+settingsRouter.post("/prompt-configs-reset-all", (c) => {
+	const manager = new PromptConfigManager(getWorkspaceDir());
+	return c.json(manager.resetAll());
 });
 
 // ── LLM Providers ─────────────────────────────────────────

--- a/packages/dashboard/src/ui/dashboard.html
+++ b/packages/dashboard/src/ui/dashboard.html
@@ -369,6 +369,22 @@ tr:hover td { background: rgba(255,255,255,0.02); }
 .eval-tab-btn:hover { color: var(--text); background: var(--surface2); }
 .eval-tab-btn.active { color: var(--primary); border-bottom-color: var(--primary); }
 /* Collapsible sections */
+/* Prompt Config: category group */
+.pc-category { border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 12px; }
+.pc-category-header { display: flex; align-items: center; justify-content: space-between; padding: 12px 16px; cursor: pointer; font-size: 14px; font-weight: 600; background: var(--surface2); border-radius: var(--radius); list-style: none; }
+.pc-category-header::-webkit-details-marker { display: none; }
+.pc-category-header > span::before { content: '\25B6'; font-size: 10px; margin-right: 8px; display: inline-block; transition: transform 0.2s; }
+.pc-category[open] > .pc-category-header > span::before { transform: rotate(90deg); }
+.pc-category-body { padding: 4px 8px 8px 8px; }
+/* Prompt Config: individual item */
+.pc-item { margin-bottom: 2px; border-radius: var(--radius); }
+.pc-item > summary { display: flex; align-items: center; gap: 8px; padding: 6px 12px; cursor: pointer; font-size: 13px; border-radius: var(--radius); list-style: none; }
+.pc-item > summary::-webkit-details-marker { display: none; }
+.pc-item > summary:hover { background: var(--surface2); }
+.pc-item-name { flex: 1; font-weight: 500; }
+.pc-item-badges { display: flex; align-items: center; gap: 4px; }
+.pc-item-preview { padding: 4px 12px 8px 12px; font-size: 11px; color: var(--text-muted); font-family: monospace; white-space: pre-wrap; max-height: 80px; overflow: hidden; line-height: 1.4; }
+
 details.collapsible { border: 1px solid var(--border); border-radius: var(--radius); margin-bottom: 12px; }
 details.collapsible > summary { padding: 12px 16px; cursor: pointer; font-size: 13px; font-weight: 600; color: var(--text-muted); background: var(--surface2); border-radius: var(--radius); list-style: none; display: flex; align-items: center; gap: 8px; }
 details.collapsible > summary::before { content: '\25B6'; font-size: 10px; transition: transform 0.2s; }
@@ -407,7 +423,7 @@ details.collapsible > .collapsible-content { padding: 16px; }
 <div class="nav">
 	<button class="active" data-tab="targets">Targets</button>
 	<button data-tab="pipelines">Pipelines</button>
-	<button data-tab="prompts">Agent Prompts</button>
+	<button data-tab="prompts">Prompts</button>
 	<button data-tab="evaluation">Evaluation</button>
 	<button data-tab="llm">LLM Providers</button>
 </div>
@@ -432,13 +448,13 @@ details.collapsible > .collapsible-content { padding: 16px; }
 		<div id="pipelinesContent"></div>
 	</div>
 
-	<!-- Agent Prompts Tab -->
+	<!-- All Prompts & Templates Tab -->
 	<div id="tab-prompts" class="hidden">
 		<div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:16px;">
-			<h2 style="font-size:18px;">Agent Prompts</h2>
-			<button class="btn btn-ghost" onclick="resetAllPrompts()">Reset All</button>
+			<h2 style="font-size:18px;">All Prompts & Templates</h2>
+			<button class="btn btn-ghost" onclick="resetAllPromptConfigs()">Reset All</button>
 		</div>
-		<div id="promptsContent"></div>
+		<div id="promptConfigsContent"></div>
 	</div>
 
 	<!-- Evaluation Tab -->
@@ -514,7 +530,7 @@ details.collapsible > .collapsible-content { padding: 16px; }
 	</div>
 </div>
 
-<!-- Edit Prompt Modal -->
+<!-- Edit Prompt Modal (legacy) -->
 <div id="promptModal" class="modal-overlay hidden">
 	<div class="modal">
 		<h2 id="promptModalTitle">Edit Prompt</h2>
@@ -527,6 +543,31 @@ details.collapsible > .collapsible-content { padding: 16px; }
 			<button class="btn btn-ghost" onclick="closeModal('promptModal')">Cancel</button>
 			<button class="btn btn-danger" onclick="resetPrompt()" style="margin-right:auto;">Reset to Default</button>
 			<button class="btn btn-primary" onclick="savePrompt()">Save</button>
+		</div>
+	</div>
+</div>
+
+<!-- Edit Prompt Config Modal (unified) -->
+<div id="pcModal" class="modal-overlay hidden">
+	<div class="modal" style="max-width:820px;width:90vw;">
+		<h2 id="pcModalTitle" style="font-size:16px;">Edit Prompt</h2>
+		<input type="hidden" id="pcEditId">
+		<div class="form-group">
+			<label style="font-weight:600;">Prompt Template</label>
+			<textarea id="pcPromptTemplate" rows="14" style="font-family:monospace;font-size:12px;"></textarea>
+		</div>
+		<div class="form-group">
+			<label style="font-weight:600;">System Instruction</label>
+			<textarea id="pcSystemInstruction" rows="6" style="font-family:monospace;font-size:12px;"></textarea>
+		</div>
+		<details style="margin-bottom:12px;">
+			<summary style="cursor:pointer;font-size:12px;color:var(--text-muted);font-weight:600;">Template Variables Reference</summary>
+			<div id="pcVarsRef" style="font-size:11px;padding:8px;background:var(--surface2);border-radius:var(--radius);margin-top:4px;max-height:120px;overflow:auto;"></div>
+		</details>
+		<div class="actions">
+			<button class="btn btn-ghost" onclick="closeModal('pcModal')">Cancel</button>
+			<button class="btn btn-danger" onclick="resetPromptConfig()" style="margin-right:auto;">Reset to Default</button>
+			<button class="btn btn-primary" onclick="savePromptConfig()">Save</button>
 		</div>
 	</div>
 </div>
@@ -569,6 +610,7 @@ details.collapsible > .collapsible-content { padding: 16px; }
 const API = window.location.origin;
 let targets = [];
 let prompts = [];
+let promptConfigGroups = [];
 let providers = [];
 
 // ── Redeploy ─────────────────────────────────────────
@@ -602,7 +644,7 @@ function switchTab(tabName) {
 	window.location.hash = tabName;
 	if (tabName === 'targets') loadTargets();
 	if (tabName === 'pipelines') loadPipelines();
-	if (tabName === 'prompts') loadPrompts();
+	if (tabName === 'prompts') loadPromptConfigs();
 	if (tabName === 'llm') loadLLMProviders();
 	if (tabName === 'evaluation') initEvalTab();
 }
@@ -3524,69 +3566,136 @@ function toggleLLMDetail(row) {
 	}
 }
 
-// ── Agent Prompts ────────────────────────────────────
+// ── Agent Prompts (legacy — kept for backward compat) ──
 async function loadPrompts() {
 	try {
 		prompts = await api('/api/settings/agents/prompts');
 		renderPrompts();
 	} catch (e) { toast(e.message, 'error'); }
 }
+function renderPrompts() {}
+function editPrompt(agentId) {}
+async function savePrompt() {}
+async function resetPrompt() {}
+async function resetAllPrompts() {}
 
-function renderPrompts() {
-	const container = document.getElementById('promptsContent');
-	container.innerHTML = prompts.map(p => `<div class="card">
-		<div style="display:flex;justify-content:space-between;align-items:center;">
-			<div>
-				<h2>${esc(p.agent_id)}</h2>
-				<div style="font-size:12px;color:var(--text-muted);">
-					${p.is_customized ? '<span class="badge badge-yellow">Customized</span>' : '<span class="badge badge-gray">Default</span>'}
-					${p.last_modified ? ' | Last modified: ' + new Date(p.last_modified).toLocaleString() : ''}
-				</div>
-			</div>
-			<button class="btn btn-ghost btn-sm" onclick="editPrompt('${p.agent_id}')">Edit</button>
-		</div>
-		<div style="margin-top:8px;font-size:12px;color:var(--text-muted);white-space:pre-wrap;max-height:60px;overflow:hidden;">${esc((p.system_instruction||'').slice(0,200))}...</div>
-	</div>`).join('');
-}
-
-function editPrompt(agentId) {
-	const p = prompts.find(x => x.agent_id === agentId);
-	if (!p) return;
-	document.getElementById('promptModalTitle').textContent = 'Edit: ' + agentId;
-	document.getElementById('promptEditId').value = agentId;
-	document.getElementById('promptText').value = p.system_instruction || '';
-	document.getElementById('promptModal').classList.remove('hidden');
-}
-
-async function savePrompt() {
-	const agentId = document.getElementById('promptEditId').value;
+// ── Unified Prompt Configs (All Categories) ──────────
+async function loadPromptConfigs() {
 	try {
-		await api('/api/settings/agents/prompts/' + agentId, {
+		promptConfigGroups = await api('/api/settings/prompt-configs');
+		renderPromptConfigs();
+	} catch (e) { toast(e.message, 'error'); }
+}
+
+function renderPromptConfigs() {
+	const container = document.getElementById('promptConfigsContent');
+	if (!container || !promptConfigGroups.length) {
+		if (container) container.innerHTML = '<div class="empty">No prompt configurations found.</div>';
+		return;
+	}
+
+	container.innerHTML = promptConfigGroups.map(group => {
+		const customCount = group.items.filter(i => i.is_customized).length;
+		const badge = customCount > 0 ? ' <span class="badge badge-yellow">' + customCount + ' customized</span>' : '';
+
+		const itemsHtml = group.items.map(item => {
+			const preview = esc((item.prompt_template || item.system_instruction || '').slice(0, 150));
+			const itemBadge = item.is_customized
+				? '<span class="badge badge-yellow">Customized</span>'
+				: '<span class="badge badge-gray">Default</span>';
+			const modified = item.last_modified && item.is_customized
+				? '<span style="font-size:11px;color:var(--text-muted);margin-left:8px;">' + new Date(item.last_modified).toLocaleString() + '</span>'
+				: '';
+
+			return '<details class="pc-item">' +
+				'<summary>' +
+					'<span class="pc-item-name">' + esc(item.display_name) + '</span>' +
+					'<span class="pc-item-badges">' + itemBadge + modified + '</span>' +
+					'<button class="btn btn-ghost btn-sm" onclick="event.stopPropagation();editPromptConfig(\'' + esc(item.id) + '\')">Edit</button>' +
+				'</summary>' +
+				'<div class="pc-item-preview">' + preview + (preview.length >= 150 ? '...' : '') + '</div>' +
+			'</details>';
+		}).join('');
+
+		return '<details class="pc-category" open>' +
+			'<summary class="pc-category-header">' +
+				'<span>' + group.icon + ' ' + esc(group.label) + ' <span class="badge badge-gray">' + group.items.length + '</span>' + badge + '</span>' +
+				'<button class="btn btn-ghost btn-sm" onclick="event.stopPropagation();resetPromptCategory(\'' + group.category + '\')">Reset Category</button>' +
+			'</summary>' +
+			'<div class="pc-category-body">' + itemsHtml + '</div>' +
+		'</details>';
+	}).join('');
+}
+
+function editPromptConfig(id) {
+	let item = null;
+	for (const g of promptConfigGroups) {
+		item = g.items.find(i => i.id === id);
+		if (item) break;
+	}
+	if (!item) return;
+
+	document.getElementById('pcModalTitle').textContent = item.display_name;
+	document.getElementById('pcEditId').value = id;
+	document.getElementById('pcPromptTemplate').value = item.prompt_template || '';
+	document.getElementById('pcSystemInstruction').value = item.system_instruction || '';
+
+	const varsRef = document.getElementById('pcVarsRef');
+	if (item.variables && item.variables.length > 0) {
+		varsRef.innerHTML = '<table style="width:100%;border-collapse:collapse;">' +
+			item.variables.map(v =>
+				'<tr><td style="padding:2px 8px;font-family:monospace;color:var(--primary);white-space:nowrap;">' + esc(v.name) + '</td>' +
+				'<td style="padding:2px 8px;">' + esc(v.description) + '</td></tr>'
+			).join('') + '</table>';
+	} else {
+		varsRef.innerHTML = '<span style="color:var(--text-muted);">No template variables</span>';
+	}
+
+	document.getElementById('pcModal').classList.remove('hidden');
+}
+
+async function savePromptConfig() {
+	const id = document.getElementById('pcEditId').value;
+	try {
+		await api('/api/settings/prompt-configs/' + id, {
 			method: 'PUT',
-			body: { system_instruction: document.getElementById('promptText').value },
+			body: {
+				prompt_template: document.getElementById('pcPromptTemplate').value,
+				system_instruction: document.getElementById('pcSystemInstruction').value,
+			},
 		});
 		toast('Prompt saved');
-		closeModal('promptModal');
-		loadPrompts();
+		closeModal('pcModal');
+		loadPromptConfigs();
 	} catch (e) { toast(e.message, 'error'); }
 }
 
-async function resetPrompt() {
-	const agentId = document.getElementById('promptEditId').value;
+async function resetPromptConfig() {
+	const id = document.getElementById('pcEditId').value;
+	if (!confirm('Reset this prompt to default?')) return;
 	try {
-		await api('/api/settings/agents/prompts/' + agentId + '/reset', { method: 'POST' });
+		await api('/api/settings/prompt-configs/' + id + '/reset', { method: 'POST' });
 		toast('Prompt reset to default');
-		closeModal('promptModal');
-		loadPrompts();
+		closeModal('pcModal');
+		loadPromptConfigs();
 	} catch (e) { toast(e.message, 'error'); }
 }
 
-async function resetAllPrompts() {
-	if (!confirm('Reset all agent prompts to defaults?')) return;
+async function resetPromptCategory(category) {
+	if (!confirm('Reset all prompts in this category to defaults?')) return;
 	try {
-		await api('/api/settings/agents/prompts/reset-all', { method: 'POST' });
+		await api('/api/settings/prompt-configs-reset-category/' + category, { method: 'POST' });
+		toast('Category reset to defaults');
+		loadPromptConfigs();
+	} catch (e) { toast(e.message, 'error'); }
+}
+
+async function resetAllPromptConfigs() {
+	if (!confirm('Reset ALL prompts and templates to defaults?')) return;
+	try {
+		await api('/api/settings/prompt-configs-reset-all', { method: 'POST' });
 		toast('All prompts reset');
-		loadPrompts();
+		loadPromptConfigs();
 	} catch (e) { toast(e.message, 'error'); }
 }
 


### PR DESCRIPTION
## Summary
- Dashboard Prompts 탭에서 시스템 전체 32개 프롬프트/템플릿을 7개 카테고리별로 조회/편집/리셋 가능하도록 확장
- 기존 Agent System Prompts 6개만 노출되던 것을 SKILL.md, Evaluation Templates, Probe Definitions, Judgment, Optimization, Strategy & Validation 프롬프트까지 모두 포함
- 2-depth 접기/펼치기 UI (카테고리 그룹 → 개별 프롬프트) 적용

## Changes

### Core (packages/core)
- `models/prompt-config.ts` — PromptConfigItem, PromptCategory, PromptConfigGroup 통합 모델
- `prompts/prompt-defaults.ts` — 32개 프롬프트 기본값 레지스트리 (7 카테고리)
- `prompts/prompt-config-manager.ts` — PromptConfigManager (load/save/reset/loadGrouped) + resolvePrompt()
- `agents/probes/synthetic-probes.ts` — getProbeDefinitions(workspaceDir) 커스텀 템플릿 로드 지원

### Dashboard (packages/dashboard)
- `routes/settings.ts` — 6개 신규 API 엔드포인트 (/api/settings/prompt-configs CRUD)
- `ui/dashboard.html` — Prompts 탭 재설계: 카테고리 그룹 + 개별 접기/펼치기 + 편집 모달 (prompt_template + system_instruction + 변수 참조)

### 카테고리 구성
| 카테고리 | 항목 수 | 설명 |
|----------|---------|------|
| Agent System Prompts | 6 | orchestrator, analysis, strategy, optimization, validation, monitoring |
| Analysis Skill | 1 | geo-analysis SKILL.md |
| Evaluation Templates | 3 | manufacturer, research, generic |
| Probe Definitions | 9 | P-01~P-08 쿼리 + probe system instruction |
| Judgment Prompts | 4 | citation_check, accuracy_estimation, fact_judgment, citation_judgment |
| Optimization Prompts | 7 | meta_desc, og, json_ld, llms_txt, h1, content_density, faq |
| Strategy & Validation | 2 | strategy_generation, validation_assessment |

## Test plan
- [x] `npm run build` — clean rebuild 성공
- [x] `vitest run` — 1704 tests passed, 0 failures
- [ ] Dashboard에서 Prompts 탭 열기 → 7개 카테고리 그룹 확인
- [ ] 개별 프롬프트 Edit → prompt_template + system_instruction 편집 → Save → Customized 뱃지 확인
- [ ] Reset to Default → Default 뱃지 복원 확인
- [ ] Reset Category / Reset All 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)