### PR TITLE
Fix: multipage 0점 회귀 방지 — 미채점 페이지 자동 score_geo fallback

### DIFF
--- a/packages/core/src/agents/analysis/llm-analysis-agent.test.ts
+++ b/packages/core/src/agents/analysis/llm-analysis-agent.test.ts
@@ -228,6 +228,86 @@ describe("LLM Analysis Agent", () => {
 		});
 	});
 
+	describe("post-loop multipage score fallback", () => {
+		const subPageCrawlData: CrawlData = {
+			...mockCrawlData,
+			url: "https://example.com/products/phones/",
+			title: "Phones",
+			canonical_url: "https://example.com/products/phones/",
+		};
+		const subPage2CrawlData: CrawlData = {
+			...mockCrawlData,
+			url: "https://example.com/about/",
+			title: "About",
+			canonical_url: "https://example.com/about/",
+		};
+
+		function setupMultipageState() {
+			const state = createAnalysisToolState();
+			state.homepageCrawl = mockCrawlData;
+			state.multiPageResult = {
+				homepage: mockCrawlData,
+				pages: [
+					{
+						url: "https://example.com/products/phones/",
+						path: "/products/phones/",
+						crawl_data: subPageCrawlData,
+					},
+					{ url: "https://example.com/about/", path: "/about/", crawl_data: subPage2CrawlData },
+				],
+				total_pages: 3,
+				crawl_duration_ms: 5000,
+			};
+			return state;
+		}
+
+		it("should auto-score unscored multipage pages in post-loop fallback", async () => {
+			const state = setupMultipageState();
+			const handlers = createAnalysisToolHandlers(mockDeps, state);
+
+			// Simulate: LLM scored homepage but skipped sub-pages (iteration limit)
+			await handlers.score_geo({ crawl_data_key: "homepage" });
+			expect(state.pageScores.has("homepage")).toBe(true);
+			expect(state.pageScores.has("https://example.com/products/phones/")).toBe(false);
+			expect(state.pageScores.has("https://example.com/about/")).toBe(false);
+
+			// Simulate post-loop fallback logic from llm-analysis-agent.ts
+			for (const page of state.multiPageResult!.pages) {
+				if (!state.pageScores.has(page.url)) {
+					await handlers.score_geo({ crawl_data_key: page.url });
+				}
+			}
+
+			// All pages should now have scores
+			expect(state.pageScores.has("https://example.com/products/phones/")).toBe(true);
+			expect(state.pageScores.has("https://example.com/about/")).toBe(true);
+			expect(state.pageScores.get("https://example.com/products/phones/")!.overall_score).toBe(65);
+			expect(state.pageScores.get("https://example.com/about/")!.overall_score).toBe(65);
+		});
+
+		it("should not re-score pages already scored by LLM", async () => {
+			const state = setupMultipageState();
+			const handlers = createAnalysisToolHandlers(mockDeps, state);
+
+			// LLM scored homepage and one sub-page
+			await handlers.score_geo({ crawl_data_key: "homepage" });
+			await handlers.score_geo({ crawl_data_key: "https://example.com/products/phones/" });
+
+			const callCountBefore = (mockDeps.scoreTarget as any).mock.calls.length;
+
+			// Post-loop fallback — should only score the missing /about/ page
+			for (const page of state.multiPageResult!.pages) {
+				if (!state.pageScores.has(page.url)) {
+					await handlers.score_geo({ crawl_data_key: page.url });
+				}
+			}
+
+			const callCountAfter = (mockDeps.scoreTarget as any).mock.calls.length;
+			// Only 1 additional scoreTarget call (for /about/), not 2
+			expect(callCountAfter - callCountBefore).toBe(1);
+		});
+	});
+
 	describe("LLMAnalysisResult type contract", () => {
 		it("should have mandatory richReport field", () => {
 			const mockResult: LLMAnalysisResult = {

--- a/packages/core/src/agents/analysis/llm-analysis-agent.ts
+++ b/packages/core/src/agents/analysis/llm-analysis-agent.ts
@@ -117,6 +117,14 @@ export async function runLLMAnalysis(
 	if (!state.pageScores.has("homepage")) {
 		await toolHandlers.score_geo({ crawl_data_key: "homepage" });
 	}
+	// Ensure all multi-page scores exist — LLM may skip pages due to iteration limits
+	if (state.multiPageResult) {
+		for (const page of state.multiPageResult.pages) {
+			if (!state.pageScores.has(page.url)) {
+				await toolHandlers.score_geo({ crawl_data_key: page.url });
+			}
+		}
+	}
 	if (!state.evalData) {
 		await toolHandlers.extract_evaluation_data({});
 	}


### PR DESCRIPTION
## Summary
- PR #74에서 수정한 multipage 0점 버그가 LLM iteration 한도로 인해 재발하는 구조적 취약점 해소
- Agent loop 종료 후 `multiPageResult`의 모든 페이지에 대해 `pageScores` 존재 여부를 확인하고, 미채점 페이지를 자동으로 `score_geo` 호출하는 안전망 추가
- PR #74의 URL 매칭 수정(path/suffix fallback)은 LLM이 호출은 하되 key 포맷이 틀린 경우만 커버 — LLM이 호출 자체를 skip한 경우는 여전히 0점 폴백 발생

## Root Cause
| PR #74가 해결한 문제 | 이번 PR이 해결하는 문제 |
|---|---|
| LLM이 `score_geo`를 path로 호출 → URL 매칭 실패 → 0점 | LLM이 `score_geo`를 아예 호출하지 않음 (iteration 소진) → 0점 |

`maxIterations: 15`에서 필수 도구 9종 + 개별 페이지 N개 채점이 필요하여, 10+페이지 사이트에서는 iteration 한도 내에 모든 페이지를 채점하지 못할 수 있음.

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `packages/core/src/agents/analysis/llm-analysis-agent.ts` | post-loop fallback에 multipage score 안전망 추가 (5줄) |
| `packages/core/src/agents/analysis/llm-analysis-agent.test.ts` | regression 테스트 2개 추가 (미채점 자동 채점, 중복 채점 방지) |

## Test plan
- [x] 기존 11개 테스트 통과
- [x] 신규 2개 테스트 통과 (자동 채점 + 중복 방지)
- [ ] 실제 multipage 사이트 분석 실행하여 모든 페이지 점수 > 0 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)