### PR TITLE
Azure Open AI / Google Vertex AI support

### DIFF
--- a/packages/core/src/agents/analysis/llm-analysis-agent.ts
+++ b/packages/core/src/agents/analysis/llm-analysis-agent.ts
@@ -101,7 +101,7 @@ export async function runLLMAnalysis(
 		apiKey,
 		maxIterations: 15,
 		temperature: 0.3,
-		maxTokens: 8192,
+		maxTokens: model.maxTokens ?? 16384,
 	});
 
 	// Ensure critical tools were called — if LLM skipped them, call them now

--- a/packages/core/src/agents/probes/provider-probe-runner.ts
+++ b/packages/core/src/agents/probes/provider-probe-runner.ts
@@ -52,7 +52,9 @@ export function createProviderChatLLM(provider: LLMProviderSettings): ChatLLMFn 
 	const model = piAiModelFromProvider(provider);
 
 	return async (request: LLMRequest): Promise<LLMResponse> => {
-		return piAiComplete(model, request, { apiKey: provider.api_key });
+		const response = await piAiComplete(model, request, { apiKey: provider.api_key });
+		response.provider = provider.provider_id;
+		return response;
 	};
 }
 

--- a/packages/core/src/llm/geo-llm-client.ts
+++ b/packages/core/src/llm/geo-llm-client.ts
@@ -141,6 +141,9 @@ export class GeoLLMClient {
 
 		const response = await piAiComplete(piModel, request, { apiKey: provider.api_key });
 
+		// pi-ai의 내부 provider 이름(e.g. "openai")이 아닌 원래 GEO provider_id(e.g. "microsoft")로 표시
+		response.provider = provider.provider_id;
+
 		this.costTracker.record(
 			provider.provider_id,
 			response.model,

--- a/packages/core/src/llm/pi-ai-bridge.test.ts
+++ b/packages/core/src/llm/pi-ai-bridge.test.ts
@@ -181,6 +181,7 @@ describe("pi-ai-bridge", () => {
 			{ provider_id: "google", model: "gemini-99-future", expectedApi: "google-generative-ai" },
 			{ provider_id: "anthropic", model: "claude-99-future", expectedApi: "anthropic-messages" },
 			{ provider_id: "perplexity", model: "sonar-99-future", expectedApi: "openai-completions" },
+			{ provider_id: "microsoft", model: "gpt-5.4", expectedApi: "openai-responses" },
 		])(
 			"fallback: $provider_id with unknown model '$model' → api=$expectedApi",
 			({ provider_id, model, expectedApi }) => {
@@ -195,6 +196,10 @@ describe("pi-ai-bridge", () => {
 					max_tokens: 4096,
 					temperature: 0.3,
 					rate_limit_rpm: 60,
+					// Azure requires user-provided base URL (no default)
+					...(provider_id === "microsoft" && {
+						api_base_url: "https://test.openai.azure.com",
+					}),
 				};
 
 				const result = piAiModelFromProvider(provider);
@@ -218,6 +223,7 @@ describe("pi-ai-bridge", () => {
 			{ provider_id: "google", model: "unknown-google-model" },
 			{ provider_id: "anthropic", model: "unknown-anthropic-model" },
 			{ provider_id: "perplexity", model: "unknown-perplexity-model" },
+			{ provider_id: "microsoft", model: "unknown-azure-model" },
 		])("fallback model for $provider_id has all required fields", ({ provider_id, model }) => {
 			const provider: LLMProviderSettings = {
 				provider_id,
@@ -230,6 +236,10 @@ describe("pi-ai-bridge", () => {
 				max_tokens: 4096,
 				temperature: 0.3,
 				rate_limit_rpm: 60,
+				// Azure requires user-provided base URL (no default)
+				...(provider_id === "microsoft" && {
+					api_base_url: "https://test.openai.azure.com",
+				}),
 			};
 
 			const result = piAiModelFromProvider(provider);

--- a/packages/core/src/llm/pi-ai-bridge.test.ts
+++ b/packages/core/src/llm/pi-ai-bridge.test.ts
@@ -178,19 +178,30 @@ describe("pi-ai-bridge", () => {
 		 */
 		it.each([
 			{ provider_id: "openai", model: "gpt-99-future", expectedApi: "openai-completions" },
-			{ provider_id: "google", model: "gemini-99-future", expectedApi: "google-generative-ai" },
+			{
+				provider_id: "google",
+				model: "gemini-99-future",
+				expectedApi: "google-generative-ai",
+				apiKey: "AIzaFakeKey",
+			},
+			{
+				provider_id: "google",
+				model: "gemini-99-future",
+				expectedApi: "google-vertex",
+				apiKey: "AQ.VertexKey",
+			},
 			{ provider_id: "anthropic", model: "claude-99-future", expectedApi: "anthropic-messages" },
 			{ provider_id: "perplexity", model: "sonar-99-future", expectedApi: "openai-completions" },
 			{ provider_id: "microsoft", model: "gpt-5.4", expectedApi: "openai-responses" },
 		])(
 			"fallback: $provider_id with unknown model '$model' → api=$expectedApi",
-			({ provider_id, model, expectedApi }) => {
+			({ provider_id, model, expectedApi, apiKey }: any) => {
 				const provider: LLMProviderSettings = {
 					provider_id,
 					display_name: provider_id,
 					enabled: true,
 					auth_method: "api_key",
-					api_key: "test-key",
+					api_key: apiKey ?? "test-key",
 					default_model: model,
 					available_models: [model],
 					max_tokens: 4096,
@@ -220,36 +231,39 @@ describe("pi-ai-bridge", () => {
 		 */
 		it.each([
 			{ provider_id: "openai", model: "unknown-openai-model" },
-			{ provider_id: "google", model: "unknown-google-model" },
+			{ provider_id: "google", model: "unknown-google-model", apiKey: "AIzaFakeKey" },
 			{ provider_id: "anthropic", model: "unknown-anthropic-model" },
 			{ provider_id: "perplexity", model: "unknown-perplexity-model" },
 			{ provider_id: "microsoft", model: "unknown-azure-model" },
-		])("fallback model for $provider_id has all required fields", ({ provider_id, model }) => {
-			const provider: LLMProviderSettings = {
-				provider_id,
-				display_name: provider_id,
-				enabled: true,
-				auth_method: "api_key",
-				api_key: "test-key",
-				default_model: model,
-				available_models: [model],
-				max_tokens: 4096,
-				temperature: 0.3,
-				rate_limit_rpm: 60,
-				// Azure requires user-provided base URL (no default)
-				...(provider_id === "microsoft" && {
-					api_base_url: "https://test.openai.azure.com",
-				}),
-			};
+		])(
+			"fallback model for $provider_id has all required fields",
+			({ provider_id, model, apiKey }: any) => {
+				const provider: LLMProviderSettings = {
+					provider_id,
+					display_name: provider_id,
+					enabled: true,
+					auth_method: "api_key",
+					api_key: apiKey ?? "test-key",
+					default_model: model,
+					available_models: [model],
+					max_tokens: 4096,
+					temperature: 0.3,
+					rate_limit_rpm: 60,
+					// Azure requires user-provided base URL (no default)
+					...(provider_id === "microsoft" && {
+						api_base_url: "https://test.openai.azure.com",
+					}),
+				};
 
-			const result = piAiModelFromProvider(provider);
+				const result = piAiModelFromProvider(provider);
 
-			expect(result.id).toBeTypeOf("string");
-			expect(result.api).toBeTypeOf("string");
-			expect(result.provider).toBeTypeOf("string");
-			expect(result.baseUrl).toBeTypeOf("string");
-			expect(result.baseUrl).toMatch(/^https?:\/\//);
-		});
+				expect(result.id).toBeTypeOf("string");
+				expect(result.api).toBeTypeOf("string");
+				expect(result.provider).toBeTypeOf("string");
+				expect(result.baseUrl).toBeTypeOf("string");
+				expect(result.baseUrl).toMatch(/^https?:\/\//);
+			},
+		);
 
 		it("should override baseUrl when api_base_url is set", () => {
 			const provider: LLMProviderSettings = {

--- a/packages/core/src/llm/pi-ai-bridge.ts
+++ b/packages/core/src/llm/pi-ai-bridge.ts
@@ -50,13 +50,27 @@ export function piAiModelFromProvider(
 	provider: LLMProviderSettings,
 	costOverrides?: ModelCostOverrideMap,
 ): Model<Api> {
-	const piProvider = PROVIDER_MAP[provider.provider_id];
+	let piProvider = PROVIDER_MAP[provider.provider_id];
 	if (!piProvider) {
 		throw new Error(`Provider "${provider.provider_id}" not mapped to pi-ai provider`);
 	}
 
+	// Azure v1 model routing: use OpenAI-compatible /openai/v1/responses endpoint
+	// instead of AzureOpenAI SDK's /deployments/{name}/responses path.
+	// The v1 endpoint supports Bearer auth and model-in-body routing,
+	// which works universally across Azure OpenAI resources.
+	// Auto-append "/openai/v1" to the base URL if not already present.
+	let azureV1BaseUrl: string | undefined;
+	if (piProvider === "azure-openai-responses" && provider.api_base_url) {
+		piProvider = "openai";
+		azureV1BaseUrl = provider.api_base_url.includes("/openai/v1")
+			? provider.api_base_url
+			: `${provider.api_base_url.replace(/\/+$/, "")}/openai/v1`;
+	}
+
 	// Perplexity uses OpenAI-compatible API with custom baseUrl
 	const effectiveBaseUrl =
+		azureV1BaseUrl ??
 		provider.api_base_url ??
 		(provider.provider_id === "perplexity" ? "https://api.perplexity.ai" : undefined);
 
@@ -93,6 +107,8 @@ export function piAiModelFromProvider(
 		api = "google-generative-ai";
 	} else if (piProvider === "anthropic") {
 		api = "anthropic-messages";
+	} else if (piProvider === "azure-openai-responses") {
+		api = "azure-openai-responses";
 	} else if (modelId.includes("codex")) {
 		api = "openai-codex-responses";
 	} else if (modelId.startsWith("gpt-5") || modelId.startsWith("o3") || modelId.startsWith("o4")) {

--- a/packages/core/src/llm/pi-ai-bridge.ts
+++ b/packages/core/src/llm/pi-ai-bridge.ts
@@ -68,6 +68,12 @@ export function piAiModelFromProvider(
 			: `${provider.api_base_url.replace(/\/+$/, "")}/openai/v1`;
 	}
 
+	// Google Vertex AI: API keys starting with "AIza" are Google AI Studio keys
+	// (use google-generative-ai). All other keys are Vertex AI keys (use google-vertex).
+	if (piProvider === "google" && provider.api_key && !provider.api_key.startsWith("AIza")) {
+		piProvider = "google-vertex";
+	}
+
 	// Perplexity uses OpenAI-compatible API with custom baseUrl
 	const effectiveBaseUrl =
 		azureV1BaseUrl ??
@@ -105,6 +111,8 @@ export function piAiModelFromProvider(
 	let api: string;
 	if (piProvider === "google") {
 		api = "google-generative-ai";
+	} else if (piProvider === "google-vertex") {
+		api = "google-vertex";
 	} else if (piProvider === "anthropic") {
 		api = "anthropic-messages";
 	} else if (piProvider === "azure-openai-responses") {
@@ -149,6 +157,8 @@ function getDefaultBaseUrl(provider: string): string {
 			return "https://api.anthropic.com";
 		case "google":
 			return "https://generativelanguage.googleapis.com/v1beta";
+		case "google-vertex":
+			return "https://us-central1-aiplatform.googleapis.com";
 		default:
 			return "";
 	}
@@ -215,8 +225,14 @@ export async function piAiComplete(
 		messages,
 	};
 
+	// Gemini 2.5 thinking models: thinking tokens share the maxOutputTokens budget.
+	// Ensure sufficient room for the actual response by boosting the token limit.
+	const isGoogleThinkingModel =
+		(model.api === "google-generative-ai" || model.api === "google-vertex") &&
+		model.id.includes("2.5");
+
 	// Build onPayload: inject json_mode and/or web_search into raw API payload
-	const needsPayloadHook = request.json_mode || request.web_search;
+	const needsPayloadHook = request.json_mode || request.web_search || isGoogleThinkingModel;
 	const onPayload = needsPayloadHook
 		? (payload: unknown) => {
 				const p = payload as Record<string, unknown>;
@@ -232,12 +248,35 @@ export async function piAiComplete(
 						api === "azure-openai-responses"
 					) {
 						p.text = { format: { type: "json_object" } };
-					} else if (api === "google-generative-ai" || api === "google-vertex") {
+					} else if (api === "google-generative-ai") {
 						const gc = (p.generationConfig ?? {}) as Record<string, unknown>;
 						gc.responseMimeType = "application/json";
 						p.generationConfig = gc;
+					} else if (api === "google-vertex") {
+						const cfg = (p.config ?? {}) as Record<string, unknown>;
+						cfg.responseMimeType = "application/json";
+						p.config = cfg;
 					}
 					// Anthropic: no native json_mode — handled via prompt instructions
+				}
+
+				// ── Gemini 2.5 thinking budget ─────────────────────
+				// Thinking tokens share maxOutputTokens. Cap thinking to avoid
+				// starving the actual response of tokens.
+				if (isGoogleThinkingModel) {
+					if (api === "google-vertex") {
+						const cfg = (p.config ?? {}) as Record<string, unknown>;
+						if (!cfg.thinkingConfig) {
+							cfg.thinkingConfig = { thinkingBudget: 1024 };
+						}
+						p.config = cfg;
+					} else {
+						const gc = (p.generationConfig ?? {}) as Record<string, unknown>;
+						if (!gc.thinkingConfig) {
+							gc.thinkingConfig = { thinkingBudget: 1024 };
+						}
+						p.generationConfig = gc;
+					}
 				}
 
 				// ── web_search ──────────────────────────────────────
@@ -253,7 +292,7 @@ export async function piAiComplete(
 	const response = await complete(model, context, {
 		apiKey: options?.apiKey,
 		temperature: request.temperature,
-		maxTokens: request.max_tokens,
+		maxTokens: request.max_tokens ?? model.maxTokens,
 		onPayload,
 	});
 


### PR DESCRIPTION
  ## Summary
  - Azure OpenAI v1 모델 라우팅 자동 감지: `/openai/v1` 경로를 자동 추가하여 기존
  deployment 경로 404 문제 해결
  - Google Vertex AI API 키 자동 분기: `AIza...` → AI Studio, 그 외 → Vertex AI로 자동
  라우팅
  - Gemini 2.5 thinking 모델 토큰 예산 문제 수정: `thinkingBudget` 제한으로 응답 잘림 방지
  - pi-ai 내부 provider 이름 대신 원래 GEO provider_id 표시 (`openai/gpt-5.4` →
  `microsoft/gpt-5.4`)
  - google-vertex payload 구조 수정 (`p.generationConfig` → `p.config`)

  ## Changed files
  - `pi-ai-bridge.ts`: Azure v1 자동 전환, Vertex AI 분기, thinking budget, payload 구조
  수정
  - `geo-llm-client.ts`, `provider-probe-runner.ts`: response.provider를 원래 provider_id로
   복원
  - `llm-analysis-agent.ts`: maxTokens를 provider 설정값 반영 (기본 16384)
  - `pi-ai-bridge.test.ts`: Azure/Vertex 분기 테스트 추가
